### PR TITLE
MSH-SETUP chore: add minimal Makefile and placeholder main.c for CI build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+# **************************************************************************** #
+#                                   minishell                                  #
+# **************************************************************************** #
+
+NAME = minishell
+
+CC = cc
+CFLAGS = -Wall -Wextra -Werror
+RM = rm -f
+
+INC_DIR = include
+SRC_DIR = src
+OBJ_DIR = obj
+
+SRCS = $(SRC_DIR)/main.c
+OBJS = $(SRCS:$(SRC_DIR)/%.c=$(OBJ_DIR)/%.o)
+
+all: $(NAME)
+
+$(NAME): $(OBJS)
+	$(CC) $(CFLAGS) $(OBJS) -I$(INC_DIR) -o $(NAME)
+
+$(OBJ_DIR)/%.o: $(SRC_DIR)/%.c | $(OBJ_DIR)
+	$(CC) $(CFLAGS) -I$(INC_DIR) -c $< -o $@
+
+$(OBJ_DIR):
+	mkdir -p $(OBJ_DIR)
+
+clean:
+	$(RM) $(OBJS)
+
+fclean: clean
+	$(RM) $(NAME)
+	$(RM) -r $(OBJ_DIR)
+
+re: fclean all
+
+.PHONY: all clean fclean re

--- a/src/main.c
+++ b/src/main.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int	main(void)
+{
+	printf("minishell starting point\n");
+	return (0);
+}


### PR DESCRIPTION
## Jira
- Ticket: MSH-SETUP

## What changed
- Added a minimal 42-compliant `Makefile` (cc + `-Wall -Wextra -Werror`) with standard rules: `$(NAME)`, `all`, `clean`, `fclean`, `re`.
- Added a placeholder `src/main.c` so the project builds and CI can run a real compile step.

## Why
- Establish a correct build baseline early (team workflow + CI).
- Ensure we can enable “required status checks” in branch protection later.
- Keep Makefile compliant with 42 expectations and avoid unnecessary relinking.

## How to test
- [x] Build: `make`
- [ ] Run manual tests:
  - `./minishell` (should print placeholder output and exit cleanly)
  - `make` again (should not relink if nothing changed)
  - `make clean && make`
  - `make fclean && make`
- [x] Valgrind / leaks (if relevant): N/A (placeholder only)

## Scope & Subsystem
- Scope: Mandatory (setup)
- Subsystem: Docs

## Checklist
- [x] Subject scope respected (no accidental bonus/extra features)
- [x] Norminette checked on touched files (if applicable) (optional at this stage)
- [x] No new leaks in tested paths (Valgrind where applicable) (N/A)
- [x] No FD leaks in tested paths (pipes/redirs) (N/A)
- [x] Exit status behavior (`$?`) verified where relevant (N/A)
- [x] Signal behavior verified where relevant (N/A)
- [x] Both teammates understand the change