### PR TITLE
MSH-SETUP docs: add docs folder index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,6 @@
+# Documentation
+
+- `subject/` - official minishell subject PDF (source of truth)
+- `architecture/` - agreed design + decisions (ADRs)
+- `research/` - exploratory notes and references
+- `project-management/` - workflow, policies, definitions


### PR DESCRIPTION
## Jira
- Ticket: MSH-SETUP

## What changed
- Added `docs/README.md` as a documentation index linking to:
  - `docs/subject/` (subject PDF)
  - `docs/architecture/` (architecture + decisions)
  - `docs/research/` (exploratory notes)
  - `docs/project-management/` (workflow/process docs)

## Why
- Make the documentation easier to navigate for teammates and evaluators.
- Provide a clear entry point for employers/reviewers to understand the repo structure and process.

## How to test
- [ ] Build: `make` (N/A – docs-only change)
- [ ] Run manual tests:
  - Open `docs/README.md` and confirm links/paths match the repo structure
- [ ] Valgrind / leaks (if relevant): N/A

## Scope & Subsystem
- Scope: Mandatory (setup)
- Subsystem: Docs

## Checklist
- [x] Subject scope respected (no accidental bonus/extra features)
- [x] Norminette checked on touched files (if applicable) (N/A – docs only)
- [x] No new leaks in tested paths (Valgrind where applicable) (N/A)
- [x] No FD leaks in tested paths (pipes/redirs) (N/A)
- [x] Exit status behavior (`$?`) verified where relevant (N/A)
- [x] Signal behavior verified where relevant (N/A)
- [x] Both teammates understand the change