### PR TITLE
Chore/MSH setup ignore and readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,15 @@
+# Project outputs
+minishell
+obj/
+
+# Debug / crash dumps
+core
+core.*
+vgcore.*
+
+# Tooling
+compile_commands.json
+
 # Ubuntu-specific
 *~                     # Backup files (e.g., vim, emacs)
 *.bak                  # Backup files

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-# 42Minishell
-42 Minishell: team-built minimal Bash-like shell in C, featuring parsing, expansion, redirections, pipes, builtins, and signal handling.
+# 42 Minishell
+Team-built minimal Bash-like shell in C, featuring parsing, expansion, redirections, pipes, builtins, and signal handling.
+
+## Docs
+Project documentation lives in [`docs/README.md`](docs/README.md).


### PR DESCRIPTION
## Jira
- Ticket: MSH-SETUP

## What changed
- Updated `.gitignore` to ignore repo-specific build artifacts:
  - `minishell` binary
  - `obj/` build directory
  - core/valgrind core dumps (`core*`, `vgcore.*`)
  - `compile_commands.json`
- Updated root `README.md` to include a **Docs** section linking to `docs/README.md`.

## Why
- Keep the repository clean by preventing compiled outputs and crash artifacts from being committed.
- Make documentation easy to discover for teammates, evaluators, and employers.

## How to test
- [ ] Build: `make`
- [ ] Run manual tests:
  - Run `make` and verify `minishell` and `obj/` do not appear as tracked changes (`git status` stays clean).
  - Confirm `README.md` includes a Docs link and that `docs/README.md` path is correct.
- [ ] Valgrind / leaks (if relevant): N/A (setup/docs change)

## Scope & Subsystem
- Scope: Mandatory (setup)
- Subsystem: Docs

## Checklist
- [x] Subject scope respected (no accidental bonus/extra features)
- [x] Norminette checked on touched files (if applicable) (N/A)
- [x] No new leaks in tested paths (Valgrind where applicable) (N/A)
- [x] No FD leaks in tested paths (pipes/redirs) (N/A)
- [x] Exit status behavior (`$?`) verified where relevant (N/A)
- [x] Signal behavior verified where relevant (N/A)
- [x] Both teammates understand the change