### PR TITLE
MSH-22 feat: add non-empty commands to history

### DIFF
--- a/src/shell/main_loop.c
+++ b/src/shell/main_loop.c
@@ -1,4 +1,5 @@
 #include <readline/readline.h>
+#include <readline/history.h>
 #include "minishell.h"
 
 static int	is_blank_line(const char *line)
@@ -27,8 +28,10 @@ int	main_loop(char **envp)
 			free(line);
 			continue ;
 		}
+		add_history(line);
 		status = run_once(line, envp);
 		free(line);
 	}
+	rl_clear_history();
 	return (status);
 }


### PR DESCRIPTION
## Jira

- Ticket: MSH-22

## What changed

- Added readline history support with `add_history()`.
- Commands are added to history only after blank/whitespace-only input is filtered.
- Empty lines and whitespace-only lines are not added to history.
- Added `rl_clear_history()` before exiting the main loop.

## Why

This implements the minishell history policy for interactive input while keeping empty and whitespace-only lines out of the command history.

## How to test

- [x] `make fclean && make`
- [x] `norminette src/shell/main_loop.c`
- [x] Run `./minishell`
- [x] Press Enter on an empty line
- [x] Enter whitespace-only input
- [x] Run `ls`
- [x] Run `pwd`
- [x] Use ↑ to confirm only real commands appear in history
- [x] Press Ctrl-D to exit cleanly

## Valgrind

Tested with:

```bash
valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --track-fds=yes ./minishell
```

Result:

definitely lost: 0 bytes
indirectly lost: 0 bytes
possibly lost: 0 bytes
ERROR SUMMARY: 0 errors
File descriptors clean: only 3 standard FDs open at exit

Note: readline/libtinfo still report expected still reachable memory.