### PR TITLE
MSH-23 feat: install interactive signal handlers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ INCLUDES = -I$(INC_DIR) -I$(LIBFT_DIR)
 SRCS = $(SRC_DIR)/main.c \
 	$(SRC_DIR)/shell/main_loop.c \
 	$(SRC_DIR)/shell/run_once.c \
+	$(SRC_DIR)/signals/signals.c \
 	$(SRC_DIR)/parsing/tokenize_line.c \
 	$(SRC_DIR)/parsing/token_quoted.c \
 	$(SRC_DIR)/parsing/token_utils.c \

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -5,6 +5,7 @@
 # include <stdio.h>
 # include <unistd.h>
 # include <sys/wait.h>
+# include <signal.h>
 # include "libft.h"
 
 typedef enum e_toktype
@@ -47,6 +48,9 @@ int		add_op_token(t_token **head, t_toktype type, t_err *err);
 t_cmd	*parse_simple_cmd(t_token *tokens, t_err *err);
 void	free_cmd(t_cmd *cmd);
 
+extern volatile sig_atomic_t	g_signal;
+
+void	setup_interactive_signals(void);
 int		main_loop(char **envp);
 int		run_once(const char *line, char **envp);
 

--- a/src/shell/main_loop.c
+++ b/src/shell/main_loop.c
@@ -17,6 +17,7 @@ int	main_loop(char **envp)
 	int		status;
 
 	status = 0;
+	setup_interactive_signals();
 	while (1)
 	{
 		line = readline("minishell$ ");

--- a/src/signals/signals.c
+++ b/src/signals/signals.c
@@ -1,0 +1,20 @@
+#include "minishell.h"
+
+volatile sig_atomic_t	g_signal;
+
+static void	signal_handler(int sig)
+{
+	g_signal = sig;
+}
+
+void	setup_interactive_signals(void)
+{
+	struct sigaction	sa;
+
+	g_signal = 0;
+	sa.sa_handler = signal_handler;
+	sigemptyset(&sa.sa_mask);
+	sa.sa_flags = 0;
+	sigaction(SIGINT, &sa, NULL);
+	sigaction(SIGQUIT, &sa, NULL);
+}


### PR DESCRIPTION
## Jira

- Ticket: MSH-23

## What changed

- Added `src/signals/signals.c`.
- Added global `volatile sig_atomic_t g_signal`.
- Added interactive signal setup with `sigaction`.
- Installed handlers for `SIGINT` and `SIGQUIT`.
- Added signal declarations to `minishell.h`.
- Added `signals.c` to the Makefile.

## Why

This prepares the minishell signal infrastructure while respecting the subject rule of using at most one global variable, only to store the received signal number.

## Tests

- [x] `make fclean && make`
- [x] Manual test: blank lines
- [x] Manual test: `ls`
- [x] Manual test: `pwd`
- [x] Manual test: Ctrl-D exits cleanly
- [x] Valgrind: no definitely/indirectly/possibly lost memory
- [x] Valgrind: ERROR SUMMARY: 0 errors

## Notes

The final visual behavior for Ctrl-C and Ctrl-\ will be handled in the next signal subtasks.

## Dependency / Rebase note

This branch was created from `main` while `MSH-22` was still pending review.
Before merging this PR, if `MSH-22` is merged first, this branch should be rebased on top of the updated `main`.
Expected rebase impact is small and likely limited to `src/shell/main_loop.c`, because both tickets touch the main interactive loop.