### PR TITLE
MSH-24 feat: refresh prompt on Ctrl-C

### DIFF
--- a/src/signals/signals.c
+++ b/src/signals/signals.c
@@ -1,3 +1,4 @@
+#include <readline/readline.h>
 #include "minishell.h"
 
 volatile sig_atomic_t	g_signal;
@@ -5,6 +6,13 @@ volatile sig_atomic_t	g_signal;
 static void	signal_handler(int sig)
 {
 	g_signal = sig;
+	if (sig == SIGINT)
+	{
+		write(1, "\n", 1);
+		rl_on_new_line();
+		rl_replace_line("", 0);
+		rl_redisplay();
+	}
 }
 
 void	setup_interactive_signals(void)


### PR DESCRIPTION
## Jira

- Ticket: MSH-24

## What changed

- Updated the interactive signal handler for `SIGINT`.
- `Ctrl-C` now prints a new line.
- The current readline buffer is cleared.
- The prompt is redisplayed without exiting minishell.

## Why

This matches the expected interactive shell behavior when pressing `Ctrl-C` at the prompt.

## Tests

- [x] `make fclean && make`
- [x] Manual test: `Ctrl-C` on empty prompt
- [x] Manual test: typed input followed by `Ctrl-C`
- [x] Manual test: `ls`
- [x] Manual test: `pwd`

## Notes

`Ctrl-\` behavior will be handled separately in MSH-25.