### PR TITLE
MSH-25 feat: ignore Ctrl-backslash at prompt

### DIFF
--- a/src/signals/signals.c
+++ b/src/signals/signals.c
@@ -24,5 +24,6 @@ void	setup_interactive_signals(void)
 	sigemptyset(&sa.sa_mask);
 	sa.sa_flags = 0;
 	sigaction(SIGINT, &sa, NULL);
+	sa.sa_handler = SIG_IGN;
 	sigaction(SIGQUIT, &sa, NULL);
 }


### PR DESCRIPTION
## Jira

- Ticket: MSH-25

## What changed

- Updated interactive signal setup so `SIGQUIT` is ignored at the prompt.
- `Ctrl-\` now does nothing in interactive mode.
- Kept the existing `SIGINT` handler for `Ctrl-C`.
- Left `Ctrl-D` behavior unchanged, since it is handled by `readline()` as EOF.

## Why

The subject requires interactive mode to handle signals like Bash:

- `Ctrl-C` displays a new prompt on a new line.
- `Ctrl-D` exits the shell.
- `Ctrl-\` does nothing.

Ignoring `SIGQUIT` with `SIG_IGN` is the simplest and most targeted way to implement the required `Ctrl-\` behavior.

## Technical note

A `termios` approach was considered but not kept.

Although `tcgetattr` and `tcsetattr` are allowed by the subject, modifying terminal flags is unnecessary for this ticket. The final implementation only ignores `SIGQUIT`, avoiding changes to global terminal echo behavior.

## Tests

- [x] `make fclean && make`
- [x] Manual test: `Ctrl-C` on empty prompt
- [x] Manual test: typed input followed by `Ctrl-C`
- [x] Manual test: `Ctrl-\` on empty prompt
- [x] Manual test: typed input followed by `Ctrl-\`
- [x] Manual test: `pwd`
- [x] Manual test: `ls`
- [x] Manual test: `Ctrl-D` exits on empty prompt