### PR TITLE
MSH-12 feat: implement mandatory environment and status expansion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ INCLUDES = -I$(INC_DIR) -I$(LIBFT_DIR)
 SRCS = $(SRC_DIR)/main.c \
 	$(SRC_DIR)/shell/main_loop.c \
 	$(SRC_DIR)/shell/run_once.c \
+	$(SRC_DIR)/expansion/expand_env.c \
+	$(SRC_DIR)/expansion/expand_utils.c \
 	$(SRC_DIR)/signals/signals.c \
 	$(SRC_DIR)/parsing/tokenize_line.c \
 	$(SRC_DIR)/parsing/token_quoted.c \

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,13 @@ SRCS = $(SRC_DIR)/main.c \
 	$(SRC_DIR)/expansion/expand_utils.c \
 	$(SRC_DIR)/signals/signals.c \
 	$(SRC_DIR)/parsing/tokenize_line.c \
+	$(SRC_DIR)/parsing/read_word.c \
 	$(SRC_DIR)/parsing/token_quoted.c \
 	$(SRC_DIR)/parsing/token_utils.c \
 	$(SRC_DIR)/parsing/token_free.c \
 	$(SRC_DIR)/parsing/utils.c \
 	$(SRC_DIR)/parsing/cmd.c \
+	$(SRC_DIR)/parsing/cmd_free.c \
 	$(SRC_DIR)/exec/exec_simple.c \
 	$(SRC_DIR)/exec/exec_path.c \
 	$(SRC_DIR)/utils/ms_ctype.c
@@ -39,11 +41,13 @@ OBJS = $(SRCS:$(SRC_DIR)/%.c=$(OBJ_DIR)/%.o)
 
 VAL_OBJS = $(OBJ_DIR)/tests/parsing/token_parser_test.o \
 	$(OBJ_DIR)/parsing/tokenize_line.o \
+	$(OBJ_DIR)/parsing/read_word.o \
 	$(OBJ_DIR)/parsing/token_quoted.o \
 	$(OBJ_DIR)/parsing/token_utils.o \
 	$(OBJ_DIR)/parsing/token_free.o \
 	$(OBJ_DIR)/parsing/utils.o \
 	$(OBJ_DIR)/parsing/cmd.o \
+	$(OBJ_DIR)/parsing/cmd_free.o \
 	$(OBJ_DIR)/utils/ms_ctype.o
 
 all: $(NAME)

--- a/_bmad-output/planning-artifacts/MSH-12-expansion-plan.md
+++ b/_bmad-output/planning-artifacts/MSH-12-expansion-plan.md
@@ -1,0 +1,118 @@
+---
+project: 42Minishell
+jira: MSH-12
+title: Environment and Exit Status Expansion
+status: in-progress
+scope: mandatory
+date: 2026-06-09
+---
+
+# MSH-12 Expansion Plan
+
+## Goal
+
+Implement mandatory expansion for `$VAR` and `$?` using bash as the reference when behavior is ambiguous, without introducing bonus behavior or destabilizing the completed tokenizer and single-command executor.
+
+## Scope
+
+In scope:
+
+- Expand `$VAR` from the current shell environment.
+- Expand `$?` from the most recently executed foreground command or pipeline state available today.
+- Expand inside double quotes.
+- Suppress expansion inside single quotes.
+- Treat missing variables as empty.
+- Preserve mandatory token boundaries expected by the parser and executor.
+- Keep the implementation compatible with later builtins, redirections, and pipelines.
+
+Out of scope:
+
+- Wildcard expansion.
+- Logical operators.
+- Parentheses.
+- Brace expansion.
+- Command substitution.
+- Arithmetic expansion.
+- Field splitting beyond what mandatory parsing requires.
+- Bonus behavior in mandatory code paths.
+
+## Current Dependencies
+
+Completed foundations:
+
+- MSH-11 tokenizer handles plain words, single quotes, double quotes, and unclosed quote rejection.
+- MSH-13 executor accepts parsed single-command argv and stores command status.
+- Invalid commands currently return status 127 and the shell remains alive.
+
+Open dependency:
+
+- MSH-10 remains In Progress because Ctrl-\ review and MSH-26 are still open, but it does not block MSH-12 unless signal-state changes alter the shell state struct.
+
+## Required Design Decisions
+
+1. Expansion must run after tokenization has preserved quote context and before final argv is executed.
+2. Token data must retain enough quote metadata to distinguish:
+   - single-quoted segments: no expansion
+   - double-quoted segments: expansion allowed
+   - unquoted segments: expansion allowed
+3. `$?` must read from the shell state field that is updated by the executor.
+4. Expansion should return allocated strings with clear ownership by the caller, matching existing cleanup patterns.
+5. Expansion failures caused by allocation errors should stop execution of the current command and return control to the prompt.
+
+## Subtasks as Commits Inside the MSH-12 Parent PR
+
+| Commit | Subtask | Acceptance |
+| --- | --- | --- |
+| 1 | Add expansion interface | Provide a small expansion API that accepts token data plus shell state and returns expanded token/argv data with documented ownership. |
+| 2 | Implement `$?` expansion | `$?` expands to the last stored status before the current command executes. Confirm `badcmd` then `/bin/echo $?` prints `127`. |
+| 3 | Implement `$VAR` lookup | Existing environment names expand from `envp`; missing names expand to empty. |
+| 4 | Enforce quote rules | Single quotes suppress expansion; double quotes and unquoted text allow expansion. |
+| 5 | Integrate with parser/executor | Existing single-command external execution continues to work with expanded argv. |
+| 6 | Add focused manual checks | Document and run mandatory expansion cases, including missing vars, quoted vars, and exit status. |
+| 7 | Leak and regression pass | Re-run `make fclean && make` and Valgrind on representative expansion paths. |
+
+## Acceptance Criteria
+
+- `$USER` or another known env variable expands in an executable command.
+- `$?` reflects the last foreground command status.
+- Expansion occurs inside double quotes.
+- Expansion does not occur inside single quotes.
+- Missing variables expand to empty without crashing.
+- Existing tokenization behavior remains unchanged for plain words and quotes.
+- Existing single external command execution still passes for PATH, absolute path, and direct executable path cases.
+- Command-not-found still returns status 127.
+- The shell returns to the prompt after expansion errors or invalid commands.
+- Tested paths remain free of shell-owned leaks.
+
+## Suggested Review Script
+
+Run after building:
+
+```sh
+make fclean && make
+./minishell
+```
+
+Manual checks inside minishell:
+
+```sh
+/bin/echo $PATH
+/bin/echo "$PATH"
+/bin/echo '$PATH'
+not_a_real_command
+/bin/echo $?
+/bin/echo "$?"
+/bin/echo $MISSING_MINISHELL_VAR
+/bin/echo pre$MISSING_MINISHELL_VARpost
+/bin/echo pre"$MISSING_MINISHELL_VAR"post
+```
+
+Expected behavior should be compared against bash for mandatory syntax only.
+
+## Handoff Notes
+
+- Do not refactor tokenization broadly unless required to preserve quote context.
+- Keep one parent branch and one PR for MSH-12.
+- Treat each subtask above as a commit in that parent PR.
+- Do not include builtins, redirections, pipes, wildcards, logical operators, or parentheses in this PR.
+

--- a/_bmad-output/planning-artifacts/project-status-snapshot-2026-06-09.md
+++ b/_bmad-output/planning-artifacts/project-status-snapshot-2026-06-09.md
@@ -1,0 +1,73 @@
+---
+project: 42Minishell
+date: 2026-06-09
+status: planning-snapshot
+source:
+  - _bmad-output/planning-artifacts/minishell-backlog-mandatory-vs-bonus.md
+  - _bmad-output/planning-artifacts/sprint-1.md
+  - current project state supplied by team
+---
+
+# Project Status Snapshot - 2026-06-09
+
+## Executive Summary
+
+42Minishell has completed the first mandatory vertical slice:
+
+- interactive prompt loop
+- readline integration
+- non-empty command history
+- prompt-mode signal baseline
+- mandatory quote-aware tokenization
+- single external command execution
+- PATH, absolute path, and direct executable path resolution
+- stable shell recovery after invalid command execution
+- clean Valgrind result for tested paths
+
+Mandatory work remains the only active delivery track. Bonus scope stays parked until the mandatory epic is complete, stable, and reviewed.
+
+## Current Jira-Aligned Status
+
+| Jira | Area | Status | Notes |
+| --- | --- | --- | --- |
+| MSH-10 | Interactive Shell Bootstrap and Signal Baseline | In Progress | Parent remains open because MSH-25 is in review and MSH-26 remains open. |
+| MSH-11 | Mandatory Tokenization and Syntax Validation | Done | Plain words, single quotes, double quotes, unclosed quote rejection, and loop integration are complete. |
+| MSH-12 | Environment and Exit Status Expansion | In Progress | Active mandatory work. Must integrate with existing tokenization and last-status state. |
+| MSH-13 | External Command Resolution and Single Command Execution | Done | PATH lookup, absolute paths, direct executable paths, fork, execve, wait, status 127, and shell recovery are verified. |
+| MSH-14 | Mandatory Builtins | To Do | Must follow mandatory-only option support. |
+| MSH-15 | Mandatory Redirections and Heredoc | To Do | Includes fd setup, restoration, heredoc input, and error behavior. |
+| MSH-16 | Multi-Command Pipelines | To Do | Depends on builtins and redirections for full mandatory behavior. |
+| MSH-17 | Mandatory Stability, Test Matrix, and README | To Do | Final hardening, regression matrix, memory checks, and documentation gate. |
+| MSH-18 | Bonus Logical Operators and Parentheses | Parked | Bonus only. Do not start before mandatory is accepted. |
+| MSH-19 | Bonus Wildcard Expansion | Parked | Bonus only. Do not start before mandatory is accepted. |
+
+## Verified Capabilities
+
+- `make fclean && make` passes.
+- Prompt loop works.
+- `readline` is used.
+- Non-empty commands are added to history.
+- `Ctrl-C` refreshes the prompt.
+- `Ctrl-D` exits from an empty prompt.
+- `Ctrl-\` behavior is implemented in PR MSH-25 and waiting for review.
+- Tokenizer handles plain words, single quotes, double quotes, and unclosed quotes.
+- Tokenizer is integrated into the loop.
+- Single external commands run via `PATH`.
+- Absolute paths run.
+- Direct executable paths run.
+- `fork`, `execve`, and `wait` work for one command.
+- Invalid command returns status 127 and the shell stays alive.
+- Valgrind shows 0 definitely lost, 0 indirectly lost, 0 possibly lost, and 0 errors for tested paths. Still reachable memory is mostly from readline/libtinfo.
+
+## Active Risks
+
+1. MSH-10 is not fully closed until MSH-25 review is accepted and MSH-26 is completed.
+2. MSH-12 expansion can corrupt token boundaries if implemented as plain string rewriting without quote context.
+3. Builtins in MSH-14 will need explicit parent-context behavior for `cd`, `export`, `unset`, and `exit`.
+4. Redirections, heredoc, and pipelines introduce fd lifetime risk. MSH-15 and MSH-16 should keep fd ownership explicit.
+5. Bonus tickets MSH-18 and MSH-19 must remain parked to avoid mandatory-path instability.
+
+## Next Recommended Action
+
+Finish MSH-12 in the current parent PR/branch, then move to MSH-14. Do not start MSH-15 or MSH-16 until expansion and builtin routing decisions are settled enough to avoid rework.
+

--- a/_bmad-output/planning-artifacts/remaining-mandatory-work.md
+++ b/_bmad-output/planning-artifacts/remaining-mandatory-work.md
@@ -1,0 +1,122 @@
+---
+project: 42Minishell
+date: 2026-06-09
+scope: mandatory
+---
+
+# Remaining Mandatory Work
+
+## Delivery Rule
+
+Mandatory work ships before bonus work. MSH-18 and MSH-19 remain parked until MSH-10 through MSH-17 are complete, stable, reviewed, and accepted.
+
+## Status Overview
+
+| Jira | Status | Remaining Work |
+| --- | --- | --- |
+| MSH-10 | In Progress | Complete MSH-25 review, finish MSH-26, then close the parent. |
+| MSH-11 | Done | Regression coverage only. |
+| MSH-12 | In Progress | Finish expansion for `$VAR`, `$?`, quote rules, missing vars, and integration. |
+| MSH-13 | Done | Regression coverage only. |
+| MSH-14 | To Do | Implement mandatory builtins and parent-context routing. |
+| MSH-15 | To Do | Implement redirections and heredoc. |
+| MSH-16 | To Do | Implement multi-command pipelines. |
+| MSH-17 | To Do | Final stability, test matrix, memory checks, and README. |
+
+## MSH-10: Interactive Shell Bootstrap and Signal Baseline
+
+Remaining:
+
+- Complete review of PR MSH-25 for `Ctrl-\`.
+- Complete MSH-26.
+- Confirm the parent still satisfies:
+  - prompt display
+  - `readline`
+  - non-empty history
+  - `Ctrl-C` fresh prompt
+  - `Ctrl-D` empty-prompt exit
+  - `Ctrl-\` no-op at interactive prompt
+  - at most one global variable storing only the signal number
+
+## MSH-12: Environment and Exit Status Expansion
+
+Remaining:
+
+- Implement quote-aware expansion.
+- Expand `$VAR` from environment.
+- Expand `$?` from last foreground status.
+- Confirm missing variables expand to empty.
+- Preserve argv boundaries for existing single-command execution.
+- Verify bash-aligned behavior for mandatory cases.
+- Run build and leak checks on success and error paths.
+
+## MSH-14: Mandatory Builtins
+
+Remaining:
+
+- `echo` with `-n`.
+- `cd` with relative and absolute path input.
+- `pwd` with no options.
+- `export` with no options.
+- `unset` with no options.
+- `env` with no options or arguments.
+- `exit` with no options.
+- Parent-context behavior for stateful builtins when not in a pipeline.
+- Clear errors and statuses aligned with bash mandatory expectations.
+
+## MSH-15: Mandatory Redirections and Heredoc
+
+Remaining:
+
+- Parse and apply `<`.
+- Parse and apply `>`.
+- Parse and apply `>>`.
+- Parse and apply `<<`.
+- Read heredoc until delimiter.
+- Keep heredoc input out of command history.
+- Restore file descriptors after command execution.
+- Prevent fd leaks across prompt iterations and later commands.
+- Stop affected command on redirection errors with appropriate status reporting.
+
+## MSH-16: Multi-Command Pipelines
+
+Remaining:
+
+- Chain commands with `|`.
+- Support more than one pipe pair.
+- Close unused pipe fds in parent and child paths.
+- Run external commands and builtins correctly in pipeline contexts.
+- Update `$?` from the most recent foreground pipeline.
+- Verify pipeline behavior with redirections once MSH-15 is complete.
+
+## MSH-17: Mandatory Stability, Test Matrix, and README
+
+Remaining:
+
+- Build a focused mandatory regression matrix:
+  - prompt behavior
+  - signals
+  - tokenization and quote errors
+  - expansion
+  - builtins
+  - redirections
+  - heredoc
+  - pipelines
+  - command failure statuses
+  - memory cleanup
+- Run `make fclean && make`.
+- Run Valgrind on representative success and failure paths.
+- Review fd behavior for redirections and pipelines.
+- Update root `README.md` with the required intro line, English description, instructions, and resources/AI usage section.
+- Capture Jira-ready verification notes for each mandatory subsystem.
+
+## Recommended Order
+
+1. Close remaining MSH-10 items.
+2. Finish MSH-12.
+3. Implement MSH-14.
+4. Implement MSH-15.
+5. Implement MSH-16.
+6. Complete MSH-17.
+7. Only then revisit MSH-18 and MSH-19.
+

--- a/_bmad-output/planning-artifacts/sprint-2.md
+++ b/_bmad-output/planning-artifacts/sprint-2.md
@@ -1,0 +1,184 @@
+# Sprint 2
+
+## Sprint Goal
+
+Complete the next mandatory shell slice:
+
+- environment and exit-status expansion
+- mandatory builtins
+- redirections and heredoc groundwork if capacity allows after expansion and builtins are reviewable
+
+Sprint 2 remains mandatory-only. Bonus tickets MSH-18 and MSH-19 stay parked.
+
+## Current Entry State
+
+Done:
+
+- MSH-11 Mandatory Tokenization and Syntax Validation.
+- MSH-13 External Command Resolution and Single Command Execution.
+
+In progress:
+
+- MSH-10 Interactive Shell Bootstrap and Signal Baseline because MSH-25 is in review and MSH-26 remains open.
+- MSH-12 Environment and Exit Status Expansion.
+
+To do:
+
+- MSH-14 Mandatory Builtins.
+- MSH-15 Mandatory Redirections and Heredoc.
+- MSH-16 Multi-Command Pipelines.
+- MSH-17 Mandatory Stability, Test Matrix, and README.
+
+## Selected Stories
+
+### MSH-12: Environment and Exit Status Expansion
+
+Included this sprint:
+
+- `$VAR` expansion from the shell environment.
+- `$?` expansion from the last foreground command status.
+- Expansion inside double quotes.
+- No expansion inside single quotes.
+- Missing variable behavior aligned with bash mandatory expectations.
+- Integration with existing tokenization, parsing, and single-command execution.
+
+Excluded this sprint:
+
+- Wildcards.
+- Logical operators.
+- Parentheses.
+- Command substitution.
+- Arithmetic expansion.
+
+### MSH-14: Mandatory Builtins
+
+Included this sprint:
+
+- `echo` with `-n`.
+- `cd` with relative or absolute path input.
+- `pwd` with no options.
+- `export` with no options.
+- `unset` with no options.
+- `env` with no options or arguments.
+- `exit` with no options.
+- Parent-context execution for stateful builtins when not in a pipeline.
+
+Excluded this sprint:
+
+- Non-subject options.
+- Bash-compatible advanced option parsing outside mandatory requirements.
+- Pipeline-specific builtin isolation if MSH-16 has not started.
+
+### MSH-15: Mandatory Redirections and Heredoc, Optional Sprint 2 Pull-In
+
+Pull this story only after MSH-12 and MSH-14 are reviewable.
+
+Included if pulled:
+
+- `<`, `>`, `>>`, and `<<` token handling through existing mandatory syntax structures.
+- File open behavior and error reporting.
+- fd setup and restoration for a single command.
+- Heredoc delimiter reading.
+
+Excluded if pulled:
+
+- Multi-command pipeline fd chaining.
+- Bonus syntax.
+
+## Task Split
+
+### Luís
+
+Primary ownership:
+
+- shell state integration
+- last-status behavior
+- parent-context builtin execution
+- prompt-loop behavior after expansion and builtin errors
+
+Concrete tasks:
+
+- Wire `$?` to the existing last-status field.
+- Keep prompt behavior stable after expansion and builtin failures.
+- Implement or integrate `cd`, `export`, `unset`, and `exit` parent-context routing.
+- Verify `Ctrl-C`, `Ctrl-D`, and pending `Ctrl-\` behavior still match mandatory expectations.
+
+### João
+
+Primary ownership:
+
+- expansion engine
+- env lookup
+- argv integration
+- non-stateful builtins and external-command regression checks
+
+Concrete tasks:
+
+- Implement `$VAR` expansion with quote awareness.
+- Preserve token boundaries required by the parser and executor.
+- Implement or integrate `echo`, `pwd`, and `env`.
+- Maintain PATH, absolute path, direct executable path, and command-not-found behavior.
+
+### Shared Integration
+
+- Agree on the expansion API and ownership before coding.
+- Pair on stateful builtin review because these affect future pipelines.
+- Run bash comparison checks for ambiguous mandatory behavior.
+- Update PR descriptions with exact manual verification commands.
+
+## Integration Order
+
+1. Close or account for remaining MSH-10 review items without changing MSH-12 scope.
+2. Finish MSH-12 expansion API and `$?` support.
+3. Add `$VAR` lookup and quote-rule coverage.
+4. Integrate expanded argv into current single-command execution.
+5. Implement mandatory builtins in MSH-14.
+6. Add parent-context routing for stateful builtins.
+7. Pull MSH-15 only if MSH-12 and MSH-14 are reviewable and stable.
+
+## Risks and Mitigations
+
+### Risk 1: Expansion changes token boundaries
+
+- **Impact:** commands execute with incorrect argv.
+- **Mitigation:** preserve quote context from tokenizer through expansion; compare representative cases against bash.
+
+### Risk 2: Builtins mutate state in the wrong process
+
+- **Impact:** `cd`, `export`, `unset`, or `exit` appear to run but do not affect the shell.
+- **Mitigation:** route stateful builtins through parent context when there is no pipeline.
+
+### Risk 3: Redirection fd handling leaks into later commands
+
+- **Impact:** prompt or subsequent commands inherit wrong input/output.
+- **Mitigation:** if MSH-15 is pulled in, implement fd save/restore before broad heredoc behavior.
+
+### Risk 4: Bonus behavior slips into mandatory
+
+- **Impact:** review complexity and unstable mandatory paths.
+- **Mitigation:** reject MSH-18 and MSH-19 work during Sprint 2. Any wildcard or logical-operator behavior belongs in a parked future sprint.
+
+## Demo Scenarios
+
+Use these for Sprint 2 review.
+
+1. Run `/bin/echo $PATH`.
+2. Run `/bin/echo "$PATH"`.
+3. Run `/bin/echo '$PATH'`.
+4. Run `not_a_real_command`, then `/bin/echo $?`.
+5. Run `echo -n hello` if builtin `echo` is included.
+6. Run `pwd`, then `cd ..`, then `pwd` if builtin `cd` is included.
+7. Run `export`, `unset`, and `env` with mandatory-only supported forms if included.
+8. Run `exit` from an interactive prompt and confirm clean shutdown if included.
+
+## Definition of Done
+
+Sprint 2 is done when:
+
+- MSH-12 is implemented, reviewed, and passes manual bash comparison for mandatory expansion cases.
+- MSH-14 is implemented or explicitly remains next if Sprint 2 scope is reduced.
+- Existing MSH-11 and MSH-13 behavior has not regressed.
+- `make fclean && make` passes.
+- Shell-owned allocations are clean on tested paths.
+- PRs follow the rule: one parent Jira ticket equals one branch and one PR; subtasks are commits inside the parent PR.
+

--- a/_bmad-output/planning-artifacts/technical-decisions.md
+++ b/_bmad-output/planning-artifacts/technical-decisions.md
@@ -1,0 +1,88 @@
+---
+project: 42Minishell
+date: 2026-06-09
+status: living-decisions
+---
+
+# Technical Decisions
+
+## TD-001: Mandatory Before Bonus
+
+Decision: Complete and stabilize all mandatory stories before starting MSH-18 or MSH-19.
+
+Reason: Bonus behavior changes parser and expansion semantics. Mixing it into mandatory paths increases review risk and can hide mandatory regressions.
+
+Implication: Wildcards, logical operators, and parentheses are not accepted in MSH-12 through MSH-17 PRs.
+
+## TD-002: Bash Is the Reference for Ambiguous Behavior
+
+Decision: Use bash as the behavior reference when the 42 subject is ambiguous.
+
+Reason: The backlog already defines bash as the mandatory ambiguity reference.
+
+Implication: PR descriptions should include the bash comparison command when behavior is subtle.
+
+## TD-003: One Parent Jira Ticket Equals One Branch and One PR
+
+Decision: Each parent Jira item uses one branch and one GitHub PR.
+
+Reason: Keeps review aligned to delivery scope and avoids cross-ticket partial merges.
+
+Implication: MSH-12 subtasks are commits inside the MSH-12 PR, not separate branches or separate PRs.
+
+## TD-004: Expansion Runs After Quote-Aware Tokenization
+
+Decision: Expansion should consume tokenizer output that preserves quote context.
+
+Reason: `$VAR` and `$?` must expand in unquoted and double-quoted content, but not inside single quotes.
+
+Implication: Avoid implementing expansion as a blind full-line string rewrite.
+
+## TD-005: Shell State Owns Last Status
+
+Decision: `$?` reads from shell state updated after foreground command execution.
+
+Reason: Current execution already tracks single-command status, including status 127 for invalid commands.
+
+Implication: Future pipelines must update the same state with the status of the most recent foreground pipeline.
+
+## TD-006: Builtins That Mutate Shell State Run in Parent Context When Not Pipelined
+
+Decision: `cd`, `export`, `unset`, and `exit` must run in the parent shell context for non-pipeline commands.
+
+Reason: Running these only in a child process would discard required shell state changes.
+
+Implication: MSH-14 should create explicit builtin routing before MSH-16 pipeline isolation.
+
+## TD-007: External Execution Remains Fork/Execve Based
+
+Decision: External commands continue to run through `fork`, `execve`, and `wait` or `waitpid`.
+
+Reason: This is already implemented and verified for one command.
+
+Implication: Expansion and builtins should integrate without replacing the working execution path.
+
+## TD-008: Redirections Own File Descriptor Setup and Restoration
+
+Decision: MSH-15 should make fd ownership explicit for redirection setup, command execution, and restoration.
+
+Reason: Redirection and heredoc errors can otherwise leak modified stdin/stdout into the prompt or later commands.
+
+Implication: Single-command redirection should be stable before multi-command pipeline fd chaining.
+
+## TD-009: Heredoc Input Is Not Added to History
+
+Decision: Heredoc input lines are not recorded as readline command history.
+
+Reason: The backlog acceptance criteria explicitly separates heredoc input from history updates.
+
+Implication: Heredoc reading should not reuse the normal prompt loop history behavior without a guard.
+
+## TD-010: Memory Verification Tracks Shell-Owned Allocations
+
+Decision: Valgrind review focuses on shell-owned allocations while recognizing still-reachable memory from readline/libtinfo.
+
+Reason: Current verified results show no definitely, indirectly, or possibly lost memory on tested paths, with still reachable mostly from external libraries.
+
+Implication: Each mandatory PR should include leak checks for success and error paths it changes.
+

--- a/docs/architecture/MSH-12-expansion-flow.md
+++ b/docs/architecture/MSH-12-expansion-flow.md
@@ -1,0 +1,179 @@
+# MSH-12 Expansion Flow
+
+## Goal
+
+Document where mandatory expansion happens in the current Minishell execution flow.
+
+This file explains how MSH-12 integrates environment variable expansion and last exit status expansion before command parsing and execution.
+
+## Current Flow
+
+main_loop()
+  -> run_once(line, &shell)
+      -> tokenize_line(line, shell, &err)
+          -> read_word()
+              -> read_plain_segment()
+                  -> expand_env_vars()
+              -> read_double_quoted()
+                  -> expand_env_vars()
+              -> read_single_quoted()
+                  -> no expansion
+      -> parse_simple_cmd(tokens, &err)
+      -> exec_simple_cmd(cmd, shell->envp)
+
+## Design Decision
+
+Expansion is performed during tokenization, while quote context is still available.
+
+This is important because the tokenizer removes quote characters. If expansion happened after tokenization, the shell would no longer know whether a piece of text originally came from:
+
+- unquoted input
+- single-quoted input
+- double-quoted input
+
+By expanding during segment reading, the shell can apply the correct behavior before quote context disappears.
+
+## Quote Behavior
+
+| Context | Expansion behavior |
+|---|---|
+| Unquoted text | Expands `$VAR` and `$?` |
+| Single quotes | Preserves literal content |
+| Double quotes | Expands `$VAR` and `$?` |
+
+## Integration Point
+
+Expansion happens before command parsing and execution.
+
+This means `parse_simple_cmd()` receives already-expanded `TOK_WORD` values and only builds `argv`.
+
+`exec_simple_cmd()` does not perform expansion. It only executes the command represented by `argv`.
+
+## Implemented Expansion Rules
+
+### Environment Variables
+
+The current implementation expands environment variables in unquoted and double-quoted segments.
+
+Examples:
+
+- `echo $USER`
+- `echo "$USER"`
+- `echo hello$USER`
+- `echo "hello$USER"`
+
+### Last Exit Status
+
+The current implementation expands `$?` to the shell's last exit status.
+
+Examples:
+
+- `echo $?`
+- `invalid_command`
+- `echo $?`
+- `echo "$?"`
+
+### Single Quotes
+
+Single quotes preserve literal content.
+
+Examples:
+
+- `echo '$USER'`
+- `echo '$?'`
+- `echo 'hello$USER'`
+
+These inputs should not expand `$USER` or `$?`.
+
+### Missing Variables
+
+Missing variables expand to an empty string.
+
+Examples:
+
+- `echo $THIS_VAR_DOES_NOT_EXIST`
+- `echo "$THIS_VAR_DOES_NOT_EXIST"`
+- `echo "$USERhello"`
+
+The input `$USERhello` is parsed as a lookup for the variable `USERhello`, not as `$USER` followed by `hello`.
+
+## Data Ownership
+
+Expansion functions return newly allocated strings.
+
+The caller is responsible for freeing temporary strings after they are joined into the final token value.
+
+Current ownership flow:
+
+read_plain_segment()
+  -> ft_substr()
+  -> expand_env_vars()
+  -> free(original segment)
+  -> return(expanded segment)
+
+read_double_quoted()
+  -> ft_substr()
+  -> expand_env_vars()
+  -> free(original segment)
+  -> return(expanded segment)
+
+read_single_quoted()
+  -> ft_substr()
+  -> return(literal segment)
+
+## Error Handling
+
+If memory allocation fails during expansion:
+
+- `ERR_MALLOC` is set.
+- The current command is not executed.
+- Control returns to the prompt.
+
+If quotes are not closed:
+
+- `ERR_UNCLOSED_QUOTE` is set.
+- The current command is not executed.
+- Control returns to the prompt.
+
+## Current Limitations
+
+The following are intentionally outside the current mandatory expansion scope:
+
+- `${VAR}` syntax
+- command substitution
+- arithmetic expansion
+- wildcard expansion
+- field splitting beyond the current tokenizer behavior
+- special parameters other than `$?`
+- positional parameters such as `$1`, `$2`, `$3`
+
+## Review Checklist
+
+Use this checklist to verify the integration behavior:
+
+- `echo $USER`
+- `echo "$USER"`
+- `echo '$USER'`
+- `echo $?`
+- `invalid_command`
+- `echo $?`
+- `echo "$?"`
+- `echo '$?'`
+- `echo $THIS_VAR_DOES_NOT_EXIST`
+- `echo "$THIS_VAR_DOES_NOT_EXIST"`
+- `echo hello$USER`
+- `echo "hello$USER"`
+- `echo $USERhello`
+- `echo "$USERhello"`
+
+Expected summary:
+
+- `$USER` expands outside quotes.
+- `$USER` expands inside double quotes.
+- `$USER` stays literal inside single quotes.
+- `$?` expands outside quotes.
+- `$?` expands inside double quotes.
+- `$?` stays literal inside single quotes.
+- Missing variables expand to empty string.
+- Expansion happens before `parse_simple_cmd()`.
+- `exec_simple_cmd()` receives already-expanded `argv`.

--- a/docs/eval-prep/MSH-12-expansion-tests.md
+++ b/docs/eval-prep/MSH-12-expansion-tests.md
@@ -4,44 +4,67 @@
 
 This file tracks manual checks for mandatory environment and exit status expansion.
 
-Current implementation expands variables while reading unquoted segments, because this is the moment where quote context is still known.
+Current implementation expands variables while reading unquoted and double-quoted segments, because this is the moment where quote context is still known.
+
+Single-quoted segments are read separately and intentionally do not call expansion, preserving their literal content.
 
 ## MSH-46 - Environment variables outside single quotes
 
-| Input | Expected behavior |
-|---|---|
-| `echo $USER` | Expands `$USER` |
-| `echo $HOME` | Expands `$HOME` |
-| `echo $PATH` | Expands `$PATH` |
-| `echo $THIS_VAR_DOES_NOT_EXIST` | Expands to an empty string |
-| `echo hello$USER` | Expands and joins with surrounding text |
-| `echo $USERhello` | Looks for variable `USERhello` |
+| Input                           | Expected behavior                       |
+| ------------------------------- | --------------------------------------- |
+| `echo $USER`                    | Expands `$USER`                         |
+| `echo $HOME`                    | Expands `$HOME`                         |
+| `echo $PATH`                    | Expands `$PATH`                         |
+| `echo $THIS_VAR_DOES_NOT_EXIST` | Expands to an empty string              |
+| `echo hello$USER`               | Expands and joins with surrounding text |
+| `echo $USERhello`               | Looks for variable `USERhello`          |
 
 ## MSH-47 - Last exit status
 
-| Input | Expected behavior |
-|---|---|
-| `echo $?` after startup | Prints `0` |
-| invalid command then `echo $?` | Prints `127` |
-| `pwd` then `echo $?` | Prints `0` |
-| `echo $?text` | Expands `$?` and joins with `text` |
+| Input                          | Expected behavior                  |
+| ------------------------------ | ---------------------------------- |
+| `echo $?` after startup        | Prints `0`                         |
+| invalid command then `echo $?` | Prints `127`                       |
+| `pwd` then `echo $?`           | Prints `0`                         |
+| `echo $?text`                  | Expands `$?` and joins with `text` |
 
 ## MSH-48 - Single quote literal content
 
-| Input | Expected behavior |
-|---|---|
-| `echo '$USER'` | Prints `$USER` literally |
-| `echo '$?'` | Prints `$?` literally |
-| `echo '$HOME'` | Prints `$HOME` literally |
+| Input               | Expected behavior             |
+| ------------------- | ----------------------------- |
+| `echo '$USER'`      | Prints `$USER` literally      |
+| `echo '$?'`         | Prints `$?` literally         |
+| `echo '$HOME'`      | Prints `$HOME` literally      |
 | `echo 'hello$USER'` | Prints `hello$USER` literally |
+
+## MSH-49 - Double quote expansion
+
+| Input                | Expected behavior                                              |
+| -------------------- | -------------------------------------------------------------- |
+| `echo "$USER"`       | Expands `$USER`                                                |
+| `echo "$HOME"`       | Expands `$HOME`                                                |
+| `echo "$?"`          | Expands to the last exit status                                |
+| `echo "Hello $USER"` | Expands `$USER` inside the quoted string                       |
+| `echo "Hello$USER"`  | Expands and joins with surrounding text                        |
+| `echo "$USERhello"`  | Looks for variable `USERhello` and expands to empty if missing |
+
+## MSH-50 - Missing variables expand to empty string
+
+| Input                                 | Expected behavior                                             |
+| ------------------------------------- | ------------------------------------------------------------- |
+| `echo $THIS_VAR_DOES_NOT_EXIST`       | Prints an empty argument/output line                          |
+| `echo "$THIS_VAR_DOES_NOT_EXIST"`     | Prints an empty argument/output line                          |
+| `echo before$THIS_VAR_DOES_NOT_EXIST` | Prints `before`                                               |
+| `echo $THIS_VAR_DOES_NOT_EXISTafter`  | Looks for `THIS_VAR_DOES_NOT_EXISTafter` and expands to empty |
+| `echo "$USERhello"`                   | Looks for `USERhello` and expands to empty if missing         |
 
 ## Notes
 
-Double quote expansion is intentionally deferred to MSH-49.
+`$USERhello` is parsed as variable `USERhello`, not as `$USER` followed by `hello`.
 
-At this stage:
+`${USER}hello` style expansion is not part of the current mandatory scope.
 
-| Input | Current expected behavior |
-|---|---|
-| `echo "$USER"` | Still prints `$USER` literally |
-| `echo "$?"` | Still prints `$?` literally |
+Double quotes expand `$VAR` and `$?`.
+
+Single quotes preserve literal content and never expand `$VAR` or `$?`.
+

--- a/docs/eval-prep/MSH-12-expansion-tests.md
+++ b/docs/eval-prep/MSH-12-expansion-tests.md
@@ -1,0 +1,47 @@
+# MSH-12 Expansion Manual Tests
+
+## Scope
+
+This file tracks manual checks for mandatory environment and exit status expansion.
+
+Current implementation expands variables while reading unquoted segments, because this is the moment where quote context is still known.
+
+## MSH-46 - Environment variables outside single quotes
+
+| Input | Expected behavior |
+|---|---|
+| `echo $USER` | Expands `$USER` |
+| `echo $HOME` | Expands `$HOME` |
+| `echo $PATH` | Expands `$PATH` |
+| `echo $THIS_VAR_DOES_NOT_EXIST` | Expands to an empty string |
+| `echo hello$USER` | Expands and joins with surrounding text |
+| `echo $USERhello` | Looks for variable `USERhello` |
+
+## MSH-47 - Last exit status
+
+| Input | Expected behavior |
+|---|---|
+| `echo $?` after startup | Prints `0` |
+| invalid command then `echo $?` | Prints `127` |
+| `pwd` then `echo $?` | Prints `0` |
+| `echo $?text` | Expands `$?` and joins with `text` |
+
+## MSH-48 - Single quote literal content
+
+| Input | Expected behavior |
+|---|---|
+| `echo '$USER'` | Prints `$USER` literally |
+| `echo '$?'` | Prints `$?` literally |
+| `echo '$HOME'` | Prints `$HOME` literally |
+| `echo 'hello$USER'` | Prints `hello$USER` literally |
+
+## Notes
+
+Double quote expansion is intentionally deferred to MSH-49.
+
+At this stage:
+
+| Input | Current expected behavior |
+|---|---|
+| `echo "$USER"` | Still prints `$USER` literally |
+| `echo "$?"` | Still prints `$?` literally |

--- a/docs/eval-prep/MSH-12-expansion-tests.md
+++ b/docs/eval-prep/MSH-12-expansion-tests.md
@@ -58,6 +58,52 @@ Single-quoted segments are read separately and intentionally do not call expansi
 | `echo $THIS_VAR_DOES_NOT_EXISTafter`  | Looks for `THIS_VAR_DOES_NOT_EXISTafter` and expands to empty |
 | `echo "$USERhello"`                   | Looks for `USERhello` and expands to empty if missing         |
 
+## MSH-52 - Final Manual Validation
+
+Final validation completed for mandatory expansion behavior.
+
+Checks performed:
+
+* clean build with `make fclean && make`
+* unquoted variable expansion
+* double quote variable expansion
+* single quote literal preservation
+* last exit status expansion with `$?`
+* missing variable expansion to empty string
+* literal `$` behavior
+* unclosed quote syntax errors
+* shell continuity after syntax errors
+* basic Valgrind pass
+
+Validated behavior:
+
+* `$USER` expands outside quotes.
+* `$USER` expands inside double quotes.
+* `$USER` stays literal inside single quotes.
+* `$HOME` expands outside quotes.
+* `$HOME` expands inside double quotes.
+* `$HOME` stays literal inside single quotes.
+* `$?` expands outside quotes.
+* `$?` expands inside double quotes.
+* `$?` stays literal inside single quotes.
+* Missing variables expand to an empty string.
+* `$USERhello` is parsed as variable `USERhello`.
+* `$` alone stays literal.
+* Unclosed quotes return a syntax error and the shell stays interactive.
+* Concatenated quoted and unquoted segments still form one word when appropriate.
+
+Valgrind summary:
+
+* no definitely lost leaks
+* no indirectly lost leaks
+* no possibly lost leaks
+* no Valgrind error summary entries
+
+Known notes:
+
+* `still reachable` blocks are expected from `readline`/`libtinfo`.
+* Child-process Valgrind output may show inherited reachable memory when external command execution exits through `_exit()`.
+
 ## Notes
 
 `$USERhello` is parsed as variable `USERhello`, not as `$USER` followed by `hello`.

--- a/docs/planning/MSH-12-expansion-plan.md
+++ b/docs/planning/MSH-12-expansion-plan.md
@@ -1,0 +1,118 @@
+---
+project: 42Minishell
+jira: MSH-12
+title: Environment and Exit Status Expansion
+status: in-progress
+scope: mandatory
+date: 2026-06-09
+---
+
+# MSH-12 Expansion Plan
+
+## Goal
+
+Implement mandatory expansion for `$VAR` and `$?` using bash as the reference when behavior is ambiguous, without introducing bonus behavior or destabilizing the completed tokenizer and single-command executor.
+
+## Scope
+
+In scope:
+
+- Expand `$VAR` from the current shell environment.
+- Expand `$?` from the most recently executed foreground command or pipeline state available today.
+- Expand inside double quotes.
+- Suppress expansion inside single quotes.
+- Treat missing variables as empty.
+- Preserve mandatory token boundaries expected by the parser and executor.
+- Keep the implementation compatible with later builtins, redirections, and pipelines.
+
+Out of scope:
+
+- Wildcard expansion.
+- Logical operators.
+- Parentheses.
+- Brace expansion.
+- Command substitution.
+- Arithmetic expansion.
+- Field splitting beyond what mandatory parsing requires.
+- Bonus behavior in mandatory code paths.
+
+## Current Dependencies
+
+Completed foundations:
+
+- MSH-11 tokenizer handles plain words, single quotes, double quotes, and unclosed quote rejection.
+- MSH-13 executor accepts parsed single-command argv and stores command status.
+- Invalid commands currently return status 127 and the shell remains alive.
+
+Open dependency:
+
+- MSH-10 remains In Progress because Ctrl-\ review and MSH-26 are still open, but it does not block MSH-12 unless signal-state changes alter the shell state struct.
+
+## Required Design Decisions
+
+1. Expansion must run after tokenization has preserved quote context and before final argv is executed.
+2. Token data must retain enough quote metadata to distinguish:
+   - single-quoted segments: no expansion
+   - double-quoted segments: expansion allowed
+   - unquoted segments: expansion allowed
+3. `$?` must read from the shell state field that is updated by the executor.
+4. Expansion should return allocated strings with clear ownership by the caller, matching existing cleanup patterns.
+5. Expansion failures caused by allocation errors should stop execution of the current command and return control to the prompt.
+
+## Subtasks as Commits Inside the MSH-12 Parent PR
+
+| Commit | Subtask | Acceptance |
+| --- | --- | --- |
+| 1 | Add expansion interface | Provide a small expansion API that accepts token data plus shell state and returns expanded token/argv data with documented ownership. |
+| 2 | Implement `$?` expansion | `$?` expands to the last stored status before the current command executes. Confirm `badcmd` then `/bin/echo $?` prints `127`. |
+| 3 | Implement `$VAR` lookup | Existing environment names expand from `envp`; missing names expand to empty. |
+| 4 | Enforce quote rules | Single quotes suppress expansion; double quotes and unquoted text allow expansion. |
+| 5 | Integrate with parser/executor | Existing single-command external execution continues to work with expanded argv. |
+| 6 | Add focused manual checks | Document and run mandatory expansion cases, including missing vars, quoted vars, and exit status. |
+| 7 | Leak and regression pass | Re-run `make fclean && make` and Valgrind on representative expansion paths. |
+
+## Acceptance Criteria
+
+- `$USER` or another known env variable expands in an executable command.
+- `$?` reflects the last foreground command status.
+- Expansion occurs inside double quotes.
+- Expansion does not occur inside single quotes.
+- Missing variables expand to empty without crashing.
+- Existing tokenization behavior remains unchanged for plain words and quotes.
+- Existing single external command execution still passes for PATH, absolute path, and direct executable path cases.
+- Command-not-found still returns status 127.
+- The shell returns to the prompt after expansion errors or invalid commands.
+- Tested paths remain free of shell-owned leaks.
+
+## Suggested Review Script
+
+Run after building:
+
+```sh
+make fclean && make
+./minishell
+```
+
+Manual checks inside minishell:
+
+```sh
+/bin/echo $PATH
+/bin/echo "$PATH"
+/bin/echo '$PATH'
+not_a_real_command
+/bin/echo $?
+/bin/echo "$?"
+/bin/echo $MISSING_MINISHELL_VAR
+/bin/echo "$MISSING_MINISHELL_VAR"
+/bin/echo pre$USER
+```
+
+Expected behavior should be compared against bash for mandatory syntax only.
+
+## Handoff Notes
+
+- Do not refactor tokenization broadly unless required to preserve quote context.
+- Keep one parent branch and one PR for MSH-12.
+- Treat each subtask above as a commit in that parent PR.
+- Do not include builtins, redirections, pipes, wildcards, logical operators, or parentheses in this PR.
+

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -72,6 +72,7 @@ char	*read_double_quoted(const char *line, size_t *i, t_err *err);
 int		ms_is_var_start(char c);
 int		ms_is_var_char(char c);
 char	*ms_getenv_value(const char *name, char **envp);
+char	*copy_env_value(char *name, t_shell *shell, t_err *err);
 char	*expand_env_vars(const char *str, t_shell *shell, t_err *err);
 
 #endif

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -67,7 +67,8 @@ int		ms_is_path(const char *cmd);
 int		ms_isspace(char c);
 char	*ms_strjoin_free(char *s1, char *s2);
 char	*read_single_quoted(const char *line, size_t *i, t_err *err);
-char	*read_double_quoted(const char *line, size_t *i, t_err *err);
+char	*read_double_quoted(const char *line, size_t *i,
+			t_shell *shell, t_err *err);
 
 int		ms_is_var_start(char c);
 int		ms_is_var_char(char c);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -38,6 +38,12 @@ typedef struct s_cmd
 	int		argc;
 }	t_cmd;
 
+typedef struct s_shell
+{
+	char	**envp;
+	int		last_status;
+}	t_shell;
+
 t_token	*tokenize_line(const char *line, t_err *err);
 t_token	*token_new(t_toktype type, char *value);
 void	token_add_back(t_token **lst, t_token *new_tok);
@@ -52,7 +58,7 @@ extern volatile sig_atomic_t	g_signal;
 
 void	setup_interactive_signals(void);
 int		main_loop(char **envp);
-int		run_once(const char *line, char **envp);
+int		run_once(const char *line, t_shell *shell);
 
 int		exec_simple_cmd(t_cmd *cmd, char **envp);
 char	*find_in_path(const char *cmd, char **envp);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -44,6 +44,15 @@ typedef struct s_shell
 	int		last_status;
 }	t_shell;
 
+typedef struct s_tokctx
+{
+	const char	*line;
+	size_t		i;
+	t_token		*head;
+	t_shell		*shell;
+	t_err		*err;
+}	t_tokctx;
+
 t_token	*tokenize_line(const char *line, t_shell *shell, t_err *err);
 t_token	*token_new(t_toktype type, char *value);
 void	token_add_back(t_token **lst, t_token *new_tok);
@@ -66,6 +75,8 @@ int		ms_is_path(const char *cmd);
 
 int		ms_isspace(char c);
 char	*ms_strjoin_free(char *s1, char *s2);
+char	*read_word(const char *line, size_t *i,
+			t_shell *shell, t_err *err);
 char	*read_single_quoted(const char *line, size_t *i, t_err *err);
 char	*read_double_quoted(const char *line, size_t *i,
 			t_shell *shell, t_err *err);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -44,7 +44,7 @@ typedef struct s_shell
 	int		last_status;
 }	t_shell;
 
-t_token	*tokenize_line(const char *line, t_err *err);
+t_token	*tokenize_line(const char *line, t_shell *shell, t_err *err);
 t_token	*token_new(t_toktype type, char *value);
 void	token_add_back(t_token **lst, t_token *new_tok);
 void	free_tokens(t_token *lst);
@@ -68,5 +68,10 @@ int		ms_isspace(char c);
 char	*ms_strjoin_free(char *s1, char *s2);
 char	*read_single_quoted(const char *line, size_t *i, t_err *err);
 char	*read_double_quoted(const char *line, size_t *i, t_err *err);
+
+int		ms_is_var_start(char c);
+int		ms_is_var_char(char c);
+char	*ms_getenv_value(const char *name, char **envp);
+char	*expand_env_vars(const char *str, t_shell *shell, t_err *err);
 
 #endif

--- a/src/expansion/expand_env.c
+++ b/src/expansion/expand_env.c
@@ -1,0 +1,92 @@
+#include "minishell.h"
+
+static char	*copy_env_value(char *name, t_shell *shell, t_err *err)
+{
+	char	*value;
+	char	*copy;
+
+	value = ms_getenv_value(name, shell->envp);
+	copy = ft_substr(value, 0, ft_strlen(value));
+	if (!copy)
+		*err = ERR_MALLOC;
+	return (copy);
+}
+
+static char	*expand_dollar(const char *str, size_t *i,
+		t_shell *shell, t_err *err)
+{
+	size_t	start;
+	char	*name;
+	char	*part;
+
+	(*i)++;
+	if (!ms_is_var_start(str[*i]))
+		return (ft_substr("$", 0, 1));
+	start = *i;
+	while (ms_is_var_char(str[*i]))
+		(*i)++;
+	name = ft_substr(str, start, *i - start);
+	if (!name)
+	{
+		*err = ERR_MALLOC;
+		return (NULL);
+	}
+	part = copy_env_value(name, shell, err);
+	free(name);
+	return (part);
+}
+
+static char	*next_part(const char *str, size_t *i, t_shell *shell, t_err *err)
+{
+	char	*part;
+
+	if (str[*i] == '$')
+		return (expand_dollar(str, i, shell, err));
+	part = ft_substr(str, *i, 1);
+	if (!part)
+		*err = ERR_MALLOC;
+	(*i)++;
+	return (part);
+}
+
+static int	append_part(char **result, char *part, t_err *err)
+{
+	char	*tmp;
+
+	tmp = ms_strjoin_free(*result, part);
+	if (!tmp)
+	{
+		*err = ERR_MALLOC;
+		return (0);
+	}
+	*result = tmp;
+	return (1);
+}
+
+char	*expand_env_vars(const char *str, t_shell *shell, t_err *err)
+{
+	char	*result;
+	char	*part;
+	size_t	i;
+
+	result = ft_substr("", 0, 0);
+	if (!result)
+	{
+		*err = ERR_MALLOC;
+		return (NULL);
+	}
+	i = 0;
+	while (str[i] && *err == ERR_NONE)
+	{
+		part = next_part(str, &i, shell, err);
+		if (part && *err == ERR_NONE)
+			append_part(&result, part, err);
+		free(part);
+	}
+	if (*err != ERR_NONE)
+	{
+		free(result);
+		return (NULL);
+	}
+	return (result);
+}

--- a/src/expansion/expand_env.c
+++ b/src/expansion/expand_env.c
@@ -1,15 +1,17 @@
 #include "minishell.h"
 
-static char	*copy_env_value(char *name, t_shell *shell, t_err *err)
+static char	*expand_last_status(const char *str, size_t *i,
+		t_shell *shell, t_err *err)
 {
-	char	*value;
-	char	*copy;
+	char	*part;
 
-	value = ms_getenv_value(name, shell->envp);
-	copy = ft_substr(value, 0, ft_strlen(value));
-	if (!copy)
+	if (str[*i] != '?')
+		return (NULL);
+	(*i)++;
+	part = ft_itoa(shell->last_status);
+	if (!part)
 		*err = ERR_MALLOC;
-	return (copy);
+	return (part);
 }
 
 static char	*expand_dollar(const char *str, size_t *i,
@@ -20,6 +22,9 @@ static char	*expand_dollar(const char *str, size_t *i,
 	char	*part;
 
 	(*i)++;
+	part = expand_last_status(str, i, shell, err);
+	if (part || *err != ERR_NONE)
+		return (part);
 	if (!ms_is_var_start(str[*i]))
 		return (ft_substr("$", 0, 1));
 	start = *i;

--- a/src/expansion/expand_utils.c
+++ b/src/expansion/expand_utils.c
@@ -1,0 +1,29 @@
+#include "minishell.h"
+
+int	ms_is_var_start(char c)
+{
+	return (ft_isalpha(c) || c == '_');
+}
+
+int	ms_is_var_char(char c)
+{
+	return (ft_isalnum(c) || c == '_');
+}
+
+char	*ms_getenv_value(const char *name, char **envp)
+{
+	size_t	len;
+	int		i;
+
+	if (!name)
+		return ("");
+	len = ft_strlen(name);
+	i = 0;
+	while (envp && envp[i])
+	{
+		if (!ft_strncmp(envp[i], name, len) && envp[i][len] == '=')
+			return (envp[i] + len + 1);
+		i++;
+	}
+	return ("");
+}

--- a/src/expansion/expand_utils.c
+++ b/src/expansion/expand_utils.c
@@ -27,3 +27,15 @@ char	*ms_getenv_value(const char *name, char **envp)
 	}
 	return ("");
 }
+
+char	*copy_env_value(char *name, t_shell *shell, t_err *err)
+{
+	char	*value;
+	char	*copy;
+
+	value = ms_getenv_value(name, shell->envp);
+	copy = ft_substr(value, 0, ft_strlen(value));
+	if (!copy)
+		*err = ERR_MALLOC;
+	return (copy);
+}

--- a/src/parsing/cmd.c
+++ b/src/parsing/cmd.c
@@ -47,17 +47,28 @@ static char	**build_argv(t_token *tok, int argc, t_err *err)
 		{
 			argv[i] = ft_substr(tok->value, 0, ft_strlen(tok->value));
 			if (!argv[i])
-			{
-				*err = ERR_MALLOC;
-				free_argv(argv, i);
-				return (NULL);
-			}
+				return (free_argv(argv, i), *err = ERR_MALLOC, NULL);
 			i++;
 		}
 		tok = tok->next;
 	}
 	argv[i] = NULL;
 	return (argv);
+}
+
+static t_cmd	*cmd_new(int argc, t_err *err)
+{
+	t_cmd	*cmd;
+
+	cmd = malloc(sizeof(t_cmd));
+	if (!cmd)
+	{
+		*err = ERR_MALLOC;
+		return (NULL);
+	}
+	cmd->argc = argc;
+	cmd->argv = NULL;
+	return (cmd);
 }
 
 t_cmd	*parse_simple_cmd(t_token *tokens, t_err *err)
@@ -71,34 +82,11 @@ t_cmd	*parse_simple_cmd(t_token *tokens, t_err *err)
 	argc = count_args(tokens);
 	if (argc == 0)
 		return (NULL);
-	cmd = malloc(sizeof(t_cmd));
+	cmd = cmd_new(argc, err);
 	if (!cmd)
-	{
-		*err = ERR_MALLOC;
 		return (NULL);
-	}
-	cmd->argc = argc;
 	cmd->argv = build_argv(tokens, argc, err);
 	if (!cmd->argv)
-	{
-		free(cmd);
-		return (NULL);
-	}
+		return (free(cmd), NULL);
 	return (cmd);
-}
-
-void	free_cmd(t_cmd *cmd)
-{
-	int	i;
-
-	if (!cmd)
-		return ;
-	i = 0;
-	while (cmd->argv && i < cmd->argc)
-	{
-		free(cmd->argv[i]);
-		i++;
-	}
-	free(cmd->argv);
-	free(cmd);
 }

--- a/src/parsing/cmd_free.c
+++ b/src/parsing/cmd_free.c
@@ -1,0 +1,17 @@
+#include "minishell.h"
+
+void	free_cmd(t_cmd *cmd)
+{
+	int	i;
+
+	if (!cmd)
+		return ;
+	i = 0;
+	while (cmd->argv && i < cmd->argc)
+	{
+		free(cmd->argv[i]);
+		i++;
+	}
+	free(cmd->argv);
+	free(cmd);
+}

--- a/src/parsing/read_word.c
+++ b/src/parsing/read_word.c
@@ -1,0 +1,69 @@
+#include "minishell.h"
+
+static int	is_word_end(char c)
+{
+	return (!c || ms_isspace(c) || c == '|'
+		|| c == '<' || c == '>');
+}
+
+static char	*read_plain_segment(const char *line, size_t *i,
+		t_shell *shell, t_err *err)
+{
+	size_t	start;
+	char	*seg;
+	char	*expanded;
+
+	start = *i;
+	while (line[*i] && !is_word_end(line[*i])
+		&& line[*i] != '\'' && line[*i] != '\"')
+		(*i)++;
+	seg = ft_substr(line, start, *i - start);
+	if (!seg)
+	{
+		*err = ERR_MALLOC;
+		return (NULL);
+	}
+	expanded = expand_env_vars(seg, shell, err);
+	free(seg);
+	return (expanded);
+}
+
+static char	*read_segment(const char *line, size_t *i,
+		t_shell *shell, t_err *err)
+{
+	if (line[*i] == '\'')
+		return (read_single_quoted(line, i, err));
+	if (line[*i] == '\"')
+		return (read_double_quoted(line, i, shell, err));
+	return (read_plain_segment(line, i, shell, err));
+}
+
+static char	*join_word_segment(char *word, char *seg, t_err *err)
+{
+	char	*joined;
+
+	joined = ms_strjoin_free(word, seg);
+	if (!joined)
+		*err = ERR_MALLOC;
+	free(seg);
+	return (joined);
+}
+
+char	*read_word(const char *line, size_t *i,
+		t_shell *shell, t_err *err)
+{
+	char	*word;
+	char	*seg;
+
+	word = NULL;
+	while (!is_word_end(line[*i]))
+	{
+		seg = read_segment(line, i, shell, err);
+		if (!seg || *err != ERR_NONE)
+			return (word);
+		word = join_word_segment(word, seg, err);
+		if (!word)
+			return (NULL);
+	}
+	return (word);
+}

--- a/src/parsing/token_quoted.c
+++ b/src/parsing/token_quoted.c
@@ -22,10 +22,12 @@ char	*read_single_quoted(const char *line, size_t *i, t_err *err)
 	return (seg);
 }
 
-char	*read_double_quoted(const char *line, size_t *i, t_err *err)
+char	*read_double_quoted(const char *line, size_t *i,
+		t_shell *shell, t_err *err)
 {
 	size_t	start;
 	char	*seg;
+	char	*expanded;
 
 	(*i)++;
 	start = *i;
@@ -38,8 +40,12 @@ char	*read_double_quoted(const char *line, size_t *i, t_err *err)
 	}
 	seg = ft_substr(line, start, *i - start);
 	if (!seg)
+	{
 		*err = ERR_MALLOC;
-	else
-		(*i)++;
-	return (seg);
+		return (NULL);
+	}
+	(*i)++;
+	expanded = expand_env_vars(seg, shell, err);
+	free(seg);
+	return (expanded);
 }

--- a/src/parsing/tokenize_line.c
+++ b/src/parsing/tokenize_line.c
@@ -1,9 +1,11 @@
 #include "minishell.h"
 
-static char	*read_plain_segment(const char *line, size_t *i, t_err *err)
+static char	*read_plain_segment(const char *line, size_t *i,
+		t_shell *shell, t_err *err)
 {
 	size_t	start;
 	char	*seg;
+	char	*expanded;
 
 	start = *i;
 	while (line[*i]
@@ -16,11 +18,17 @@ static char	*read_plain_segment(const char *line, size_t *i, t_err *err)
 		(*i)++;
 	seg = ft_substr(line, start, *i - start);
 	if (!seg)
+	{
 		*err = ERR_MALLOC;
-	return (seg);
+		return (NULL);
+	}
+	expanded = expand_env_vars(seg, shell, err);
+	free(seg);
+	return (expanded);
 }
 
-static char	*read_word(const char *line, size_t *i, t_err *err)
+static char	*read_word(const char *line, size_t *i,
+		t_shell *shell, t_err *err)
 {
 	char	*word;
 	char	*seg;
@@ -37,7 +45,7 @@ static char	*read_word(const char *line, size_t *i, t_err *err)
 		else if (line[*i] == '\"')
 			seg = read_double_quoted(line, i, err);
 		else
-			seg = read_plain_segment(line, i, err);
+			seg = read_plain_segment(line, i, shell, err);
 		if (!seg || *err != ERR_NONE)
 			return (word);
 		word = ms_strjoin_free(word, seg);
@@ -83,7 +91,7 @@ static int	add_operator_token(const char *line, size_t *i,
 	return (1);
 }
 
-t_token	*tokenize_line(const char *line, t_err *err)
+t_token	*tokenize_line(const char *line, t_shell *shell, t_err *err)
 {
 	t_token	*head;
 	char	*word;
@@ -104,7 +112,7 @@ t_token	*tokenize_line(const char *line, t_err *err)
 				return (NULL);
 			continue ;
 		}
-		word = read_word(line, &i, err);
+		word = read_word(line, &i, shell, err);
 		if (!word || *err != ERR_NONE)
 		{
 			if (word)

--- a/src/parsing/tokenize_line.c
+++ b/src/parsing/tokenize_line.c
@@ -43,7 +43,7 @@ static char	*read_word(const char *line, size_t *i,
 		if (line[*i] == '\'')
 			seg = read_single_quoted(line, i, err);
 		else if (line[*i] == '\"')
-			seg = read_double_quoted(line, i, err);
+			seg = read_double_quoted(line, i, shell, err);
 		else
 			seg = read_plain_segment(line, i, shell, err);
 		if (!seg || *err != ERR_NONE)

--- a/src/parsing/tokenize_line.c
+++ b/src/parsing/tokenize_line.c
@@ -1,127 +1,82 @@
 #include "minishell.h"
 
-static char	*read_plain_segment(const char *line, size_t *i,
-		t_shell *shell, t_err *err)
+static int	add_input_operator(t_tokctx *ctx)
 {
-	size_t	start;
-	char	*seg;
-	char	*expanded;
-
-	start = *i;
-	while (line[*i]
-		&& !ms_isspace(line[*i])
-		&& line[*i] != '\''
-		&& line[*i] != '\"'
-		&& line[*i] != '|'
-		&& line[*i] != '<'
-		&& line[*i] != '>')
-		(*i)++;
-	seg = ft_substr(line, start, *i - start);
-	if (!seg)
+	if (ctx->line[ctx->i + 1] == '<')
 	{
-		*err = ERR_MALLOC;
-		return (NULL);
+		ctx->i += 2;
+		return (add_op_token(&ctx->head, TOK_HEREDOC, ctx->err));
 	}
-	expanded = expand_env_vars(seg, shell, err);
-	free(seg);
-	return (expanded);
+	ctx->i++;
+	return (add_op_token(&ctx->head, TOK_REDIR_IN, ctx->err));
 }
 
-static char	*read_word(const char *line, size_t *i,
-		t_shell *shell, t_err *err)
+static int	add_output_operator(t_tokctx *ctx)
+{
+	if (ctx->line[ctx->i + 1] == '>')
+	{
+		ctx->i += 2;
+		return (add_op_token(&ctx->head, TOK_APPEND, ctx->err));
+	}
+	ctx->i++;
+	return (add_op_token(&ctx->head, TOK_REDIR_OUT, ctx->err));
+}
+
+static int	add_operator_token(t_tokctx *ctx)
+{
+	if (ctx->line[ctx->i] == '|')
+	{
+		ctx->i++;
+		return (add_op_token(&ctx->head, TOK_PIPE, ctx->err));
+	}
+	if (ctx->line[ctx->i] == '<')
+		return (add_input_operator(ctx));
+	if (ctx->line[ctx->i] == '>')
+		return (add_output_operator(ctx));
+	return (1);
+}
+
+static int	handle_word(t_tokctx *ctx)
 {
 	char	*word;
-	char	*seg;
 
-	word = NULL;
-	while (line[*i]
-		&& !ms_isspace(line[*i])
-		&& line[*i] != '|'
-		&& line[*i] != '<'
-		&& line[*i] != '>')
+	word = read_word(ctx->line, &ctx->i, ctx->shell, ctx->err);
+	if (!word || *ctx->err != ERR_NONE)
 	{
-		if (line[*i] == '\'')
-			seg = read_single_quoted(line, i, err);
-		else if (line[*i] == '\"')
-			seg = read_double_quoted(line, i, shell, err);
-		else
-			seg = read_plain_segment(line, i, shell, err);
-		if (!seg || *err != ERR_NONE)
-			return (word);
-		word = ms_strjoin_free(word, seg);
-		if (!word)
-		{
-			free(seg);
-			*err = ERR_MALLOC;
-			return (NULL);
-		}
-		free(seg);
+		if (word)
+			free(word);
+		free_tokens(ctx->head);
+		return (0);
 	}
-	return (word);
-}
-
-static int	add_operator_token(const char *line, size_t *i,
-			t_token **head, t_err *err)
-{
-	if (line[*i] == '|')
-	{
-		(*i)++;
-		return (add_op_token(head, TOK_PIPE, err));
-	}
-	if (line[*i] == '<')
-	{
-		if (line[*i + 1] == '<')
-		{
-			*i += 2;
-			return (add_op_token(head, TOK_HEREDOC, err));
-		}
-		(*i)++;
-		return (add_op_token(head, TOK_REDIR_IN, err));
-	}
-	if (line[*i] == '>')
-	{
-		if (line[*i + 1] == '>')
-		{
-			*i += 2;
-			return (add_op_token(head, TOK_APPEND, err));
-		}
-		(*i)++;
-		return (add_op_token(head, TOK_REDIR_OUT, err));
-	}
+	if (!try_add_token(&ctx->head, word, ctx->err))
+		return (0);
 	return (1);
 }
 
 t_token	*tokenize_line(const char *line, t_shell *shell, t_err *err)
 {
-	t_token	*head;
-	char	*word;
-	size_t	i;
+	t_tokctx	ctx;
 
-	head = NULL;
+	ctx.line = line;
+	ctx.i = 0;
+	ctx.head = NULL;
+	ctx.shell = shell;
+	ctx.err = err;
 	*err = ERR_NONE;
-	i = 0;
-	while (line[i])
+	while (ctx.line[ctx.i])
 	{
-		while (line[i] && ms_isspace(line[i]))
-			i++;
-		if (!line[i])
+		while (ctx.line[ctx.i] && ms_isspace(ctx.line[ctx.i]))
+			ctx.i++;
+		if (!ctx.line[ctx.i])
 			break ;
-		if (line[i] == '|' || line[i] == '<' || line[i] == '>')
+		if (ctx.line[ctx.i] == '|' || ctx.line[ctx.i] == '<'
+			|| ctx.line[ctx.i] == '>')
 		{
-			if (!add_operator_token(line, &i, &head, err))
+			if (!add_operator_token(&ctx))
 				return (NULL);
-			continue ;
 		}
-		word = read_word(line, &i, shell, err);
-		if (!word || *err != ERR_NONE)
-		{
-			if (word)
-				free(word);
-			free_tokens(head);
-			return (NULL);
-		}
-		if (!try_add_token(&head, word, err))
+		else if (!handle_word(&ctx))
 			return (NULL);
 	}
-	return (head);
+	return (ctx.head);
 }

--- a/src/shell/main_loop.c
+++ b/src/shell/main_loop.c
@@ -14,10 +14,11 @@ static int	is_blank_line(const char *line)
 
 int	main_loop(char **envp)
 {
+	t_shell	shell;
 	char	*line;
-	int		status;
 
-	status = 0;
+	shell.envp = envp;
+	shell.last_status = 0;
 	setup_interactive_signals();
 	while (1)
 	{
@@ -30,9 +31,9 @@ int	main_loop(char **envp)
 			continue ;
 		}
 		add_history(line);
-		status = run_once(line, envp);
+		shell.last_status = run_once(line, &shell);
 		free(line);
 	}
 	rl_clear_history();
-	return (status);
+	return (shell.last_status);
 }

--- a/src/shell/run_once.c
+++ b/src/shell/run_once.c
@@ -20,12 +20,11 @@ static int	print_err(const char *msg)
 	return (1);
 }
 
-int	run_once(const char *line, char **envp)
+int	run_once(const char *line, t_shell *shell)
 {
 	t_token	*list;
 	t_cmd	*cmd;
 	t_err	err;
-	int		status;
 
 	list = tokenize_line(line, &err);
 	if (!list && err == ERR_UNCLOSED_QUOTE)
@@ -39,9 +38,9 @@ int	run_once(const char *line, char **envp)
 		return (print_err("minishell: error: malloc failed"));
 	}
 	print_tokens(list);
-	status = exec_simple_cmd(cmd, envp);
-	printf("exit status = %d\n", status);
+	shell->last_status = exec_simple_cmd(cmd, shell->envp);
+	printf("exit status = %d\n", shell->last_status);
 	free_cmd(cmd);
 	free_tokens(list);
-	return (status);
+	return (shell->last_status);
 }

--- a/src/shell/run_once.c
+++ b/src/shell/run_once.c
@@ -26,7 +26,7 @@ int	run_once(const char *line, t_shell *shell)
 	t_cmd	*cmd;
 	t_err	err;
 
-	list = tokenize_line(line, &err);
+	list = tokenize_line(line, shell, &err);
 	if (!list && err == ERR_UNCLOSED_QUOTE)
 		return (print_err("minishell: syntax error: unclosed quote"));
 	if (!list && err == ERR_MALLOC)


### PR DESCRIPTION
## Jira

* Ticket: MSH-12

## What changed

* Added mandatory environment variable expansion for `$VAR`.
* Added expansion of `$VAR` inside double quotes.
* Added expansion of `$?` to the last command exit status.
* Preserved literal content inside single quotes.
* Added behavior for missing variables to expand to an empty string.
* Added expansion context through `t_shell`, storing `envp` and `last_status`.
* Integrated expansion into the tokenization flow, before parsing and execution.
* Added manual expansion test documentation.
* Added architecture documentation for the expansion flow.
* Refactored parser/tokenizer files to fix Norminette functional issues:

  * split word reading into `read_word.c`
  * split command cleanup into `cmd_free.c`
  * reduced long parser/tokenizer functions
  * fixed tokenizer helper argument count using a context struct

## Why

* Minishell must support mandatory shell expansion behavior according to the subject.
* Expansion needs quote awareness, so it is performed during tokenization while the shell still knows whether text came from unquoted, single-quoted, or double-quoted input.
* `$?` must reflect the latest command exit status, including failed external commands.
* Missing environment variables should not print their literal name and should instead become empty strings.
* The final refactor keeps the implementation closer to Norminette requirements before review.

## How to test

* [ ] Build: `make`
* [ ] Run manual tests:

  * `echo $USER`
  * `echo "$USER"`
  * `echo '$USER'`
  * `echo $HOME`
  * `echo "$HOME"`
  * `echo '$HOME'`
  * `echo $?`
  * run an invalid command, then `echo $?`
  * `echo "$?"`
  * `echo '$?'`
  * `echo $THIS_VAR_DOES_NOT_EXIST`
  * `echo "$THIS_VAR_DOES_NOT_EXIST"`
  * `echo before$THIS_VAR_DOES_NOT_EXIST`
  * `echo $USERhello`
  * `echo "$USERhello"`
  * `echo $`
  * `echo "$"`
  * `echo '$'`
  * `echo "unterminated`
  * `echo "$USER"'d'`
* [ ] Valgrind / leaks (if relevant):

  * `valgrind --leak-check=full --show-leak-kinds=all --track-fds=yes ./minishell`
  * Confirmed:

    * definitely lost: 0 bytes
    * indirectly lost: 0 bytes
    * possibly lost: 0 bytes
    * ERROR SUMMARY: 0 errors
  * Known note:

    * `still reachable` blocks are expected from `readline`/`libtinfo`
    * child-process Valgrind output may show inherited reachable memory when invalid external commands exit through `_exit(127)`

## Scope & Subsystem

* Scope: Mandatory
* Subsystem: Expansion / Parser / Testing / Docs

## Checklist

* [ ] Subject scope respected (no accidental bonus/extra features)
* [ ] Norminette checked on touched files (if applicable)
* [ ] No new leaks in tested paths (Valgrind where applicable)
* [ ] No FD leaks in tested paths (pipes/redirs)
* [ ] Exit status behavior (`$?`) verified where relevant
* [ ] Signal behavior verified where relevant
* [ ] Both teammates understand the change
