### PR TITLE
MSH-15/feature: M6 done

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -3,6 +3,7 @@
 
 # include <stdlib.h>
 # include <stdio.h>
+# include <fcntl.h>
 # include <unistd.h>
 # include <sys/wait.h>
 # include <signal.h>
@@ -32,10 +33,18 @@ typedef enum e_err
 	ERR_UNCLOSED_QUOTE
 }	t_err;
 
+typedef struct s_redir
+{
+	t_toktype		type;
+	char			*target;
+	struct s_redir	*next;
+}	t_redir;
+
 typedef struct s_cmd
 {
 	char	**argv;
 	int		argc;
+	t_redir	*redirs;
 }	t_cmd;
 
 typedef struct s_shell
@@ -57,6 +66,7 @@ t_token	*tokenize_line(const char *line, t_shell *shell, t_err *err);
 t_token	*token_new(t_toktype type, char *value);
 void	token_add_back(t_token **lst, t_token *new_tok);
 void	free_tokens(t_token *lst);
+void	free_redirs(t_redir *list);
 int		try_add_token(t_token **head, char *word, t_err *err);
 int		add_op_token(t_token **head, t_toktype type, t_err *err);
 

--- a/src/exec/exec_simple.c
+++ b/src/exec/exec_simple.c
@@ -1,38 +1,132 @@
 #include "minishell.h"
+#include <readline/readline.h>
 
-static void	print_cmd_error(char *cmd, char *msg)
+static int	open_input(const char *path, int *fd, int *status)
 {
-	ft_putstr_fd("minishell: ", STDERR_FILENO);
-	ft_putstr_fd(cmd, STDERR_FILENO);
-	ft_putendl_fd(msg, STDERR_FILENO);
+	*fd = open(path, O_RDONLY);
+	if (*fd < 0)
+	{
+		perror(path);
+		*status = 1;
+		return (1);
+	}
+	return (0);
 }
 
-static void	exec_child(t_cmd *cmd, char **envp)
+static int	open_output(const char *path, int flags, int *fd, int *status)
 {
-	char	*path;
+	*fd = open(path, flags, 0644);
+	if (*fd < 0)
+	{
+		perror(path);
+		*status = 1;
+		return (1);
+	}
+	return (0);
+}
+static int	is_delim(const char *line, const char *delim)
+{
+	size_t	len;
 
-	if (ms_is_path(cmd->argv[0]))
+	len = ft_strlen(delim);
+	if (ft_strlen(line) != len)
+		return (0);
+	return (ft_strncmp(line, delim, len) == 0);
+}
+
+static int	setup_heredoc(const char *delim, int *fd, int *status)
+{
+	int		pipefd[2];
+	char	*line;
+
+	if (pipe(pipefd) < 0)
 	{
-		execve(cmd->argv[0], cmd->argv, envp);
-		perror("minishell");
-		_exit(1);
+		perror("pipe");
+		*status = 1;
+		return (1);
 	}
-	path = find_in_path(cmd->argv[0], envp);
-	if (!path)
+	while (1)
 	{
-		print_cmd_error(cmd->argv[0], ": command not found");
-		_exit(127);
+		line = readline("> ");
+		if (!line)
+			break ;
+		if (is_delim(line, delim))
+		{
+			free(line);
+			break ;
+		}
+		write(pipefd[1], line, ft_strlen(line));
+		write(pipefd[1], "\n", 1);
+		free(line);
 	}
-	execve(path, cmd->argv, envp);
-	print_cmd_error(path, ": cannot execute");
-	free(path);
-	_exit(126);
+	close(pipefd[1]);
+	*fd = pipefd[0];
+	return (0);
+}
+
+static int	apply_redirs(t_cmd *cmd, int *status)
+{
+	t_redir	*r;
+	int		in_fd;
+	int		out_fd;
+
+	in_fd = -1;
+	out_fd = -1;
+	r = cmd->redirs;
+	while (r)
+	{
+		if (r->type == TOK_REDIR_IN)
+		{
+			if (open_input(r->target, &in_fd, status))
+				return (1);
+		}
+		else if (r->type == TOK_REDIR_OUT)
+		{
+			if (open_output(r->target,
+					O_WRONLY | O_CREAT | O_TRUNC, &out_fd, status))
+				return (1);
+		}
+		else if (r->type == TOK_APPEND)
+		{
+			if (open_output(r->target,
+					O_WRONLY | O_CREAT | O_APPEND, &out_fd, status))
+				return (1);
+		}
+		else if (r->type == TOK_HEREDOC)
+		{
+			if (setup_heredoc(r->target, &in_fd, status))
+				return (1);
+		}
+		r = r->next;
+	}
+	if (in_fd != -1)
+	{
+		if (dup2(in_fd, STDIN_FILENO) < 0)
+		{
+			perror("dup2");
+			*status = 1;
+			return (1);
+		}
+		close(in_fd);
+	}
+	if (out_fd != -1)
+	{
+		if (dup2(out_fd, STDOUT_FILENO) < 0)
+		{
+			perror("dup2");
+			*status = 1;
+			return (1);
+		}
+		close(out_fd);
+	}
+	return (0);
 }
 
 int	exec_simple_cmd(t_cmd *cmd, char **envp)
 {
 	pid_t	pid;
 	int		status;
+	char	*path;
 
 	if (!cmd || cmd->argc == 0)
 		return (0);
@@ -40,7 +134,29 @@ int	exec_simple_cmd(t_cmd *cmd, char **envp)
 	if (pid < 0)
 		return (1);
 	if (pid == 0)
-		exec_child(cmd, envp);
+	{
+		status = 0;
+		if (apply_redirs(cmd, &status))
+			_exit(status);
+		if (ms_is_path(cmd->argv[0]))
+			execve(cmd->argv[0], cmd->argv, envp);
+		else
+		{
+			path = find_in_path(cmd->argv[0], envp);
+			if (!path)
+			{
+				fprintf(stderr, "minishell: %s: command not found\n",
+					cmd->argv[0]);
+				_exit(127);
+			}
+			execve(path, cmd->argv, envp);
+			fprintf(stderr, "minishell: %s: cannot execute\n", path);
+			free(path);
+			_exit(126);
+		}
+		perror("minishell");
+		_exit(1);
+	}
 	if (waitpid(pid, &status, 0) < 0)
 		return (1);
 	if (WIFEXITED(status))

--- a/src/parsing/cmd.c
+++ b/src/parsing/cmd.c
@@ -7,7 +7,7 @@ static int	count_args(t_token *tok)
 	count = 0;
 	while (tok)
 	{
-		if (tok->type == TOK_WORD && tok->value)
+		if (tok->type == TOK_WORD)
 			count++;
 		tok = tok->next;
 	}
@@ -29,64 +29,119 @@ static void	free_argv(char **argv, int count)
 	free(argv);
 }
 
-static char	**build_argv(t_token *tok, int argc, t_err *err)
+void	free_redirs(t_redir *list)
+{
+	t_redir	*next;
+
+	while (list)
+	{
+		next = list->next;
+		free(list->target);
+		free(list);
+		list = next;
+	}
+}
+
+static int	add_redir(t_cmd *cmd, t_toktype type, char *target, t_err *err)
+{
+	t_redir	*node;
+	t_redir	*cur;
+
+	node = malloc(sizeof(t_redir));
+	if (!node)
+	{
+		*err = ERR_MALLOC;
+		free(target);
+		return (0);
+	}
+	node->type = type;
+	node->target = target;
+	node->next = NULL;
+	if (!cmd->redirs)
+		cmd->redirs = node;
+	else
+	{
+		cur = cmd->redirs;
+		while (cur->next)
+			cur = cur->next;
+		cur->next = node;
+	}
+	return (1);
+}
+
+static int	fill_argv_and_redirs(t_cmd *cmd, t_token *tok, t_err *err)
 {
 	char	**argv;
 	int		i;
 
-	argv = malloc(sizeof(char *) * (argc + 1));
+	argv = malloc(sizeof(char *) * (cmd->argc + 1));
 	if (!argv)
 	{
 		*err = ERR_MALLOC;
-		return (NULL);
+		return (0);
 	}
 	i = 0;
 	while (tok)
 	{
-		if (tok->type == TOK_WORD && tok->value)
+		if (tok->type == TOK_WORD)
 		{
 			argv[i] = ft_substr(tok->value, 0, ft_strlen(tok->value));
 			if (!argv[i])
-				return (free_argv(argv, i), *err = ERR_MALLOC, NULL);
+			{
+				*err = ERR_MALLOC;
+				free_argv(argv, i);
+				return (0);
+			}
 			i++;
+		}
+		else if (tok->type == TOK_REDIR_IN || tok->type == TOK_REDIR_OUT
+			|| tok->type == TOK_APPEND || tok->type == TOK_HEREDOC)
+		{
+			if (!tok->next || tok->next->type != TOK_WORD)
+			{
+				*err = ERR_MALLOC;
+				free_argv(argv, i);
+				return (0);
+			}
+			if (!add_redir(cmd, tok->type,
+					ft_substr(tok->next->value, 0,
+						ft_strlen(tok->next->value)), err))
+			{
+				free_argv(argv, i);
+				return (0);
+			}
+			tok = tok->next;
 		}
 		tok = tok->next;
 	}
 	argv[i] = NULL;
-	return (argv);
+	cmd->argv = argv;
+	return (1);
 }
 
-static t_cmd	*cmd_new(int argc, t_err *err)
+t_cmd	*parse_simple_cmd(t_token *tokens, t_err *err)
 {
 	t_cmd	*cmd;
 
+	if (!tokens)
+		return (NULL);
+	*err = ERR_NONE;
 	cmd = malloc(sizeof(t_cmd));
 	if (!cmd)
 	{
 		*err = ERR_MALLOC;
 		return (NULL);
 	}
-	cmd->argc = argc;
 	cmd->argv = NULL;
-	return (cmd);
-}
-
-t_cmd	*parse_simple_cmd(t_token *tokens, t_err *err)
-{
-	t_cmd	*cmd;
-	int		argc;
-
-	if (!tokens)
+	cmd->argc = count_args(tokens);
+	cmd->redirs = NULL;
+	if (cmd->argc == 0)
+		return (cmd);
+	if (!fill_argv_and_redirs(cmd, tokens, err))
+	{
+		free_redirs(cmd->redirs);
+		free(cmd);
 		return (NULL);
-	*err = ERR_NONE;
-	argc = count_args(tokens);
-	if (argc == 0)
-		return (NULL);
-	cmd = cmd_new(argc, err);
-	if (!cmd)
-		return (NULL);
-	cmd->argv = build_argv(tokens, argc, err);
-	if (!cmd->argv)
-		return (free(cmd), NULL);
+	}
 	return (cmd);
 }

--- a/src/parsing/cmd_free.c
+++ b/src/parsing/cmd_free.c
@@ -13,5 +13,6 @@ void	free_cmd(t_cmd *cmd)
 		i++;
 	}
 	free(cmd->argv);
+	free_redirs(cmd->redirs);
 	free(cmd);
 }

--- a/src/shell/run_once.c
+++ b/src/shell/run_once.c
@@ -1,18 +1,5 @@
 #include "minishell.h"
 
-static void	print_tokens(t_token *list)
-{
-	const char	*val;
-
-	while (list)
-	{
-		val = list->value;
-		if (!val)
-			val = "(null)";
-		printf("type=%d value=%s\n", list->type, val);
-		list = list->next;
-	}
-}
 
 static int	print_err(const char *msg)
 {
@@ -37,9 +24,7 @@ int	run_once(const char *line, t_shell *shell)
 		free_tokens(list);
 		return (print_err("minishell: error: malloc failed"));
 	}
-	print_tokens(list);
 	shell->last_status = exec_simple_cmd(cmd, shell->envp);
-	printf("exit status = %d\n", shell->last_status);
 	free_cmd(cmd);
 	free_tokens(list);
 	return (shell->last_status);


### PR DESCRIPTION
## Jira
- Ticket: MSH-15 / M6

## What changed

< redirects input from a file.

> redirects output to a file with truncation.

>> redirects output in append mode.

<< reads input until the delimiter line is reached.

Heredoc input handling does not require history updates.

File descriptor setup and restoration prevent leakage into unrelated commands.

Redirection errors stop the affected command with appropriate status reporting.

## Scope & Subsystem
- Scope: Mandatory
- Subsystem: Parser / Redirections