### PR TITLE
MSH-14 Mandatory builtins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,10 @@ SRCS = $(SRC_DIR)/main.c \
 	$(SRC_DIR)/builtins/builtin_echo.c \
 	$(SRC_DIR)/builtins/builtin_pwd.c \
 	$(SRC_DIR)/builtins/builtin_env.c \
+	$(SRC_DIR)/builtins/builtin_export.c \
 	$(SRC_DIR)/env/env_copy.c \
+	$(SRC_DIR)/env/env_utils.c \
+	$(SRC_DIR)/env/env_set.c \
 	$(SRC_DIR)/expansion/expand_env.c \
 	$(SRC_DIR)/expansion/expand_utils.c \
 	$(SRC_DIR)/signals/signals.c \

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ SRCS = $(SRC_DIR)/main.c \
 	$(SRC_DIR)/builtins/builtin_export.c \
 	$(SRC_DIR)/builtins/builtin_unset.c \
 	$(SRC_DIR)/builtins/builtin_cd.c \
+	$(SRC_DIR)/builtins/builtin_exit.c \
+	$(SRC_DIR)/builtins/builtin_exit_utils.c \
 	$(SRC_DIR)/env/env_copy.c \
 	$(SRC_DIR)/env/env_entry.c \
 	$(SRC_DIR)/env/env_utils.c \

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ SRCS = $(SRC_DIR)/main.c \
 	$(SRC_DIR)/expansion/expand_env.c \
 	$(SRC_DIR)/expansion/expand_utils.c \
 	$(SRC_DIR)/signals/signals.c \
+	$(SRC_DIR)/signals/signals_exec.c \
 	$(SRC_DIR)/parsing/tokenize_line.c \
 	$(SRC_DIR)/parsing/read_word.c \
 	$(SRC_DIR)/parsing/token_quoted.c \
@@ -33,8 +34,15 @@ SRCS = $(SRC_DIR)/main.c \
 	$(SRC_DIR)/parsing/utils.c \
 	$(SRC_DIR)/parsing/cmd.c \
 	$(SRC_DIR)/parsing/cmd_free.c \
+	$(SRC_DIR)/parsing/cmd_redir.c \
 	$(SRC_DIR)/exec/exec_simple.c \
 	$(SRC_DIR)/exec/exec_path.c \
+	$(SRC_DIR)/exec/exec_wait.c \
+	$(SRC_DIR)/exec/exec_redirs.c \
+	$(SRC_DIR)/exec/exec_redir_one.c \
+	$(SRC_DIR)/exec/exec_redir_only.c \
+	$(SRC_DIR)/exec/exec_heredoc.c \
+	$(SRC_DIR)/exec/exec_redir_prepare.c \
 	$(SRC_DIR)/utils/ms_ctype.c
 
 OBJS = $(SRCS:$(SRC_DIR)/%.c=$(OBJ_DIR)/%.o)

--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,11 @@ SRCS = $(SRC_DIR)/main.c \
 	$(SRC_DIR)/shell/main_loop.c \
 	$(SRC_DIR)/shell/run_once.c \
 	$(SRC_DIR)/builtins/builtin_dispatch.c \
+	$(SRC_DIR)/builtins/builtin_parent.c \
 	$(SRC_DIR)/builtins/builtin_echo.c \
 	$(SRC_DIR)/builtins/builtin_pwd.c \
 	$(SRC_DIR)/builtins/builtin_env.c \
+	$(SRC_DIR)/env/env_copy.c \
 	$(SRC_DIR)/expansion/expand_env.c \
 	$(SRC_DIR)/expansion/expand_utils.c \
 	$(SRC_DIR)/signals/signals.c \

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ INCLUDES = -I$(INC_DIR) -I$(LIBFT_DIR)
 SRCS = $(SRC_DIR)/main.c \
 	$(SRC_DIR)/shell/main_loop.c \
 	$(SRC_DIR)/shell/run_once.c \
+	$(SRC_DIR)/builtins/builtin_dispatch.c \
+	$(SRC_DIR)/builtins/builtin_echo.c \
+	$(SRC_DIR)/builtins/builtin_pwd.c \
+	$(SRC_DIR)/builtins/builtin_env.c \
 	$(SRC_DIR)/expansion/expand_env.c \
 	$(SRC_DIR)/expansion/expand_utils.c \
 	$(SRC_DIR)/signals/signals.c \

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,9 @@ SRCS = $(SRC_DIR)/main.c \
 	$(SRC_DIR)/builtins/builtin_env.c \
 	$(SRC_DIR)/builtins/builtin_export.c \
 	$(SRC_DIR)/builtins/builtin_unset.c \
+	$(SRC_DIR)/builtins/builtin_cd.c \
 	$(SRC_DIR)/env/env_copy.c \
+	$(SRC_DIR)/env/env_entry.c \
 	$(SRC_DIR)/env/env_utils.c \
 	$(SRC_DIR)/env/env_set.c \
 	$(SRC_DIR)/env/env_unset.c \

--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,11 @@ SRCS = $(SRC_DIR)/main.c \
 	$(SRC_DIR)/builtins/builtin_pwd.c \
 	$(SRC_DIR)/builtins/builtin_env.c \
 	$(SRC_DIR)/builtins/builtin_export.c \
+	$(SRC_DIR)/builtins/builtin_unset.c \
 	$(SRC_DIR)/env/env_copy.c \
 	$(SRC_DIR)/env/env_utils.c \
 	$(SRC_DIR)/env/env_set.c \
+	$(SRC_DIR)/env/env_unset.c \
 	$(SRC_DIR)/expansion/expand_env.c \
 	$(SRC_DIR)/expansion/expand_utils.c \
 	$(SRC_DIR)/signals/signals.c \

--- a/docs/eval-prep/MSH-14-builtin-tests.md
+++ b/docs/eval-prep/MSH-14-builtin-tests.md
@@ -1,0 +1,655 @@
+# MSH-14 Mandatory Builtins Test Matrix
+
+This file documents the manual validation matrix for the mandatory builtin implementation.
+
+Related Jira ticket: MSH-14 Mandatory Builtins  
+Final validation subtask: MSH-63 Manual builtin test matrix
+
+## Scope
+
+Builtins covered:
+
+| Builtin | Mandatory scope |
+| --- | --- |
+| echo | echo with -n |
+| pwd | no options |
+| env | no options or arguments |
+| export | no options |
+| unset | no options |
+| cd | relative or absolute path |
+| exit | no options |
+
+Additional checks:
+
+| Area | Covered |
+| --- | --- |
+| Parent-context execution | yes |
+| Redirections with builtins | yes |
+| Exit status updates | yes |
+| Environment mutation | yes |
+| Valgrind | yes |
+| Norminette | yes |
+| No relink | yes |
+
+---
+
+## Build checks
+
+Run from repository root:
+
+```sh
+make fclean && make
+make
+```
+
+Expected:
+
+```text
+First make builds minishell.
+Second make prints: Nothing to be done for 'all'.
+```
+
+---
+
+## Norminette checks
+
+Run:
+
+```sh
+norminette -R CheckForbiddenSourceHeader \
+	include/minishell.h \
+	src/builtins \
+	src/env \
+	src/exec \
+	src/shell
+```
+
+Expected known notices:
+
+```text
+INVALID_HEADER
+GLOBAL_VAR_DETECTED for the allowed signal global
+```
+
+No expected issues:
+
+```text
+TOO_MANY_LINES
+TOO_MANY_FUNCS
+FORBIDDEN_CHAR_NAME
+SPC_AFTER_POINTER
+```
+
+---
+
+## echo
+
+Start minishell:
+
+```sh
+./minishell
+```
+
+Inside minishell:
+
+```sh
+echo hello
+echo hello world
+echo -n hello
+echo -nnnn hello
+echo -nnnnhello
+echo-nnnn hello
+echo $?
+exit
+```
+
+Expected behavior:
+
+| Command | Expected |
+| --- | --- |
+| `echo hello` | prints `hello` with newline |
+| `echo hello world` | prints `hello world` |
+| `echo -n hello` | prints `hello` without newline |
+| `echo -nnnn hello` | treats repeated `n` as valid `-n` |
+| `echo -nnnnhello` | prints `-nnnnhello` |
+| `echo-nnnn hello` | command not found |
+| `echo $?` | status reflects previous command |
+
+---
+
+## pwd
+
+Start minishell:
+
+```sh
+./minishell
+```
+
+Inside minishell:
+
+```sh
+pwd
+pwd > pwd.txt
+cat pwd.txt
+echo $?
+exit
+```
+
+Expected behavior:
+
+| Command | Expected |
+| --- | --- |
+| `pwd` | prints current directory |
+| `pwd > pwd.txt` | writes current directory to file |
+| `cat pwd.txt` | shows same path |
+| `echo $?` | prints `0` after successful commands |
+
+Cleanup after leaving minishell:
+
+```sh
+rm -f pwd.txt
+```
+
+---
+
+## env
+
+Start minishell:
+
+```sh
+./minishell
+```
+
+Inside minishell:
+
+```sh
+env
+env > env.txt
+cat env.txt
+echo $?
+exit
+```
+
+Expected behavior:
+
+| Command | Expected |
+| --- | --- |
+| `env` | prints current environment |
+| `env > env.txt` | writes environment to file |
+| `cat env.txt` | shows environment content |
+| `echo $?` | prints `0` |
+
+Cleanup after leaving minishell:
+
+```sh
+rm -f env.txt
+```
+
+---
+
+## export
+
+Start minishell:
+
+```sh
+./minishell
+```
+
+Inside minishell:
+
+```sh
+export TEST=hello
+env
+echo $TEST
+export TEST=world
+echo $TEST
+export ONLYNAME
+env
+export 1BAD=value
+echo $?
+export A=1 B=2 C=3
+echo $A
+echo $B
+echo $C
+export B
+echo $B
+export A=1 B = 2
+echo $A
+echo $B
+echo $?
+export > export.txt
+cat export.txt
+exit
+```
+
+Expected behavior:
+
+| Command | Expected |
+| --- | --- |
+| `export TEST=hello` | adds `TEST` |
+| `echo $TEST` | prints `hello` |
+| `export TEST=world` | replaces `TEST` value |
+| `echo $TEST` | prints `world` |
+| `export ONLYNAME` | adds exported name without value |
+| `export 1BAD=value` | prints identifier error |
+| `echo $?` | prints `1` |
+| `export A=1 B=2 C=3` | adds multiple entries |
+| `echo $A` | prints `1` |
+| `echo $B` | prints `2` |
+| `echo $C` | prints `3` |
+| `export B` | does not erase existing `B=2` |
+| `export A=1 B = 2` | preserves valid args and errors invalid tokens |
+| `export > export.txt` | redirects export output |
+
+Cleanup after leaving minishell:
+
+```sh
+rm -f export.txt
+```
+
+---
+
+## unset
+
+Start minishell:
+
+```sh
+./minishell
+```
+
+Inside minishell:
+
+```sh
+export TEST=hello A=1 B=2
+echo $TEST
+unset TEST
+echo $TEST
+unset A B
+echo $A
+echo $B
+unset DOES_NOT_EXIST
+echo $?
+unset 1BAD
+echo $?
+unset A=1
+echo $?
+exit
+```
+
+Expected behavior:
+
+| Command | Expected |
+| --- | --- |
+| `unset TEST` | removes `TEST` |
+| `echo $TEST` | prints empty line |
+| `unset A B` | removes multiple variables |
+| `unset DOES_NOT_EXIST` | no error |
+| `echo $?` | prints `0` |
+| `unset 1BAD` | identifier error |
+| `echo $?` | prints `1` |
+| `unset A=1` | identifier error |
+| `echo $?` | prints `1` |
+
+---
+
+## cd
+
+Start minishell:
+
+```sh
+./minishell
+```
+
+Inside minishell:
+
+```sh
+pwd
+echo $PWD
+echo $OLDPWD
+cd ..
+pwd
+echo $PWD
+echo $OLDPWD
+cd .
+echo $?
+cd /does/not/exist
+echo $?
+cd /tmp
+pwd
+echo $PWD
+echo $OLDPWD
+cd
+pwd
+echo $PWD
+echo $?
+cd one two
+echo $?
+exit
+```
+
+Expected behavior:
+
+| Command | Expected |
+| --- | --- |
+| `cd ..` | changes to parent directory |
+| `echo $PWD` | matches new current directory |
+| `echo $OLDPWD` | matches previous directory |
+| `cd .` | returns status `0` |
+| `cd /does/not/exist` | prints error and returns `1` |
+| `cd /tmp` | changes to `/tmp` |
+| `cd` | changes to `$HOME` |
+| `cd one two` | prints too many arguments and returns `1` |
+
+---
+
+## exit
+
+Each `exit` case should be tested in a separate shell session.
+
+### exit with no arguments
+
+Run:
+
+```sh
+./minishell
+```
+
+Inside minishell:
+
+```sh
+exit
+```
+
+After minishell exits:
+
+```sh
+echo $?
+```
+
+Expected:
+
+```text
+0
+```
+
+### exit with numeric status
+
+Run:
+
+```sh
+./minishell
+```
+
+Inside minishell:
+
+```sh
+exit 42
+```
+
+After minishell exits:
+
+```sh
+echo $?
+```
+
+Expected:
+
+```text
+42
+```
+
+### exit status wrapping
+
+Run:
+
+```sh
+./minishell
+```
+
+Inside minishell:
+
+```sh
+exit 256
+```
+
+After minishell exits:
+
+```sh
+echo $?
+```
+
+Expected:
+
+```text
+0
+```
+
+Run:
+
+```sh
+./minishell
+```
+
+Inside minishell:
+
+```sh
+exit -1
+```
+
+After minishell exits:
+
+```sh
+echo $?
+```
+
+Expected:
+
+```text
+255
+```
+
+### numeric argument required
+
+Run:
+
+```sh
+./minishell
+```
+
+Inside minishell:
+
+```sh
+exit abc
+```
+
+After minishell exits:
+
+```sh
+echo $?
+```
+
+Expected:
+
+```text
+exit
+minishell: exit: abc: numeric argument required
+2
+```
+
+### too many arguments
+
+Run:
+
+```sh
+./minishell
+```
+
+Inside minishell:
+
+```sh
+exit 1 2
+echo $?
+pwd
+exit 7
+```
+
+After minishell exits:
+
+```sh
+echo $?
+```
+
+Expected:
+
+```text
+exit
+minishell: exit: too many arguments
+1
+pwd still works after the failed exit
+7
+```
+
+---
+
+## Builtins with redirections
+
+Start minishell:
+
+```sh
+./minishell
+```
+
+Inside minishell:
+
+```sh
+echo hello > out.txt
+cat out.txt
+pwd > pwd.txt
+cat pwd.txt
+env > env.txt
+cat env.txt
+export TEST=hello > export_set.txt
+cat export_set.txt
+export > export.txt
+cat export.txt
+exit
+```
+
+Expected behavior:
+
+| Command | Expected |
+| --- | --- |
+| `echo hello > out.txt` | file contains `hello` |
+| `pwd > pwd.txt` | file contains current directory |
+| `env > env.txt` | file contains environment |
+| `export TEST=hello > export_set.txt` | assignment succeeds, usually no output |
+| `export > export.txt` | file contains export output |
+
+Cleanup after leaving minishell:
+
+```sh
+rm -f out.txt pwd.txt env.txt export_set.txt export.txt
+```
+
+---
+
+## Error status checks
+
+Start minishell:
+
+```sh
+./minishell
+```
+
+Inside minishell:
+
+```sh
+cat < missing_file
+echo $?
+export 1BAD=value
+echo $?
+unset 1BAD
+echo $?
+cd /does/not/exist
+echo $?
+cd one two
+echo $?
+exit
+```
+
+Expected behavior:
+
+| Command | Expected status |
+| --- | --- |
+| `cat < missing_file` | `1` |
+| `export 1BAD=value` | `1` |
+| `unset 1BAD` | `1` |
+| `cd /does/not/exist` | `1` |
+| `cd one two` | `1` |
+
+---
+
+## Valgrind checks
+
+Run:
+
+```sh
+valgrind --leak-check=full --show-leak-kinds=all --track-fds=yes ./minishell
+```
+
+Inside minishell:
+
+```sh
+echo hello
+pwd
+env
+export TEST=hello
+echo $TEST
+export TEST=world
+echo $TEST
+unset TEST
+echo $TEST
+cd ..
+echo $PWD
+echo $OLDPWD
+exit 42
+```
+
+Expected Valgrind summary:
+
+```text
+FILE DESCRIPTORS: 3 open (3 std) at exit
+
+definitely lost: 0 bytes in 0 blocks
+indirectly lost: 0 bytes in 0 blocks
+possibly lost: 0 bytes in 0 blocks
+ERROR SUMMARY: 0 errors from 0 contexts
+```
+
+Known acceptable output:
+
+```text
+still reachable blocks from readline/libreadline/libtinfo
+```
+
+---
+
+## Final validation summary
+
+| Check | Status |
+| --- | --- |
+| echo | PASS |
+| pwd | PASS |
+| env | PASS |
+| export | PASS |
+| unset | PASS |
+| cd | PASS |
+| exit | PASS |
+| redirections with builtins | PASS |
+| parent-context builtins | PASS |
+| exit status updates | PASS |
+| Valgrind definite/indirect/possible leaks | PASS |
+| FD leak check | PASS |
+| clean build | PASS |
+| no relink | PASS |
+| Norm known notices only | PASS |

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -148,12 +148,15 @@ int		exec_builtin_parent(t_cmd *cmd, t_shell *shell);
 int		builtin_echo(t_cmd *cmd);
 int		builtin_pwd(void);
 int		builtin_env(t_shell *shell);
+int		builtin_export(t_cmd *cmd, t_shell *shell);
 
 /* ************************************************************************** */
 /*                              ENVIRONMENT                                   */
 /* ************************************************************************** */
 
 char	**env_dup(char **envp);
+int		env_find_index(char **envp, const char *name);
+int		env_set_entry(t_shell *shell, const char *entry);
 
 /* ************************************************************************** */
 /*                                EXPANSION                                   */

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -125,7 +125,7 @@ void	setup_child_signals(void);
 /*                               EXECUTION                                    */
 /* ************************************************************************** */
 
-int		exec_simple_cmd(t_cmd *cmd, char **envp);
+int		exec_simple_cmd(t_cmd *cmd, t_shell *shell);
 int		exec_redir_only(t_cmd *cmd);
 int		wait_child(pid_t pid);
 int		apply_redirs(t_cmd *cmd, int *status);
@@ -137,6 +137,16 @@ int		prepare_redirs(t_cmd *cmd, int *status);
 int		setup_heredoc(const char *delim, int *fd, int *status);
 char	*find_in_path(const char *cmd, char **envp);
 int		ms_is_path(const char *cmd);
+
+/* ************************************************************************** */
+/*                                BUILTINS                                    */
+/* ************************************************************************** */
+
+int		is_builtin(const char *cmd);
+int		exec_builtin(t_cmd *cmd, t_shell *shell);
+int		builtin_echo(t_cmd *cmd);
+int		builtin_pwd(void);
+int		builtin_env(t_shell *shell);
 
 /* ************************************************************************** */
 /*                                EXPANSION                                   */

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -144,9 +144,16 @@ int		ms_is_path(const char *cmd);
 
 int		is_builtin(const char *cmd);
 int		exec_builtin(t_cmd *cmd, t_shell *shell);
+int		exec_builtin_parent(t_cmd *cmd, t_shell *shell);
 int		builtin_echo(t_cmd *cmd);
 int		builtin_pwd(void);
 int		builtin_env(t_shell *shell);
+
+/* ************************************************************************** */
+/*                              ENVIRONMENT                                   */
+/* ************************************************************************** */
+
+char	**env_dup(char **envp);
 
 /* ************************************************************************** */
 /*                                EXPANSION                                   */

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -149,6 +149,7 @@ int		builtin_echo(t_cmd *cmd);
 int		builtin_pwd(void);
 int		builtin_env(t_shell *shell);
 int		builtin_export(t_cmd *cmd, t_shell *shell);
+int		builtin_unset(t_cmd *cmd, t_shell *shell);
 
 /* ************************************************************************** */
 /*                              ENVIRONMENT                                   */
@@ -157,6 +158,7 @@ int		builtin_export(t_cmd *cmd, t_shell *shell);
 char	**env_dup(char **envp);
 int		env_find_index(char **envp, const char *name);
 int		env_set_entry(t_shell *shell, const char *entry);
+int		env_unset_entry(t_shell *shell, const char *name);
 
 /* ************************************************************************** */
 /*                                EXPANSION                                   */

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -150,12 +150,14 @@ int		builtin_pwd(void);
 int		builtin_env(t_shell *shell);
 int		builtin_export(t_cmd *cmd, t_shell *shell);
 int		builtin_unset(t_cmd *cmd, t_shell *shell);
+int		builtin_cd(t_cmd *cmd, t_shell *shell);
 
 /* ************************************************************************** */
 /*                              ENVIRONMENT                                   */
 /* ************************************************************************** */
 
 char	**env_dup(char **envp);
+char	*env_make_entry(const char *key, const char *value);
 int		env_find_index(char **envp, const char *name);
 int		env_set_entry(t_shell *shell, const char *entry);
 int		env_unset_entry(t_shell *shell, const char *name);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -65,6 +65,7 @@ typedef struct s_shell
 {
 	char	**envp;
 	int		last_status;
+	int		should_exit;
 }	t_shell;
 
 typedef struct s_tokctx
@@ -143,6 +144,7 @@ int		ms_is_path(const char *cmd);
 /* ************************************************************************** */
 
 int		is_builtin(const char *cmd);
+int		parse_exit_number(const char *str, long long *value);
 int		exec_builtin(t_cmd *cmd, t_shell *shell);
 int		exec_builtin_parent(t_cmd *cmd, t_shell *shell);
 int		builtin_echo(t_cmd *cmd);
@@ -151,6 +153,7 @@ int		builtin_env(t_shell *shell);
 int		builtin_export(t_cmd *cmd, t_shell *shell);
 int		builtin_unset(t_cmd *cmd, t_shell *shell);
 int		builtin_cd(t_cmd *cmd, t_shell *shell);
+int		builtin_exit(t_cmd *cmd, t_shell *shell);
 
 /* ************************************************************************** */
 /*                              ENVIRONMENT                                   */

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -1,6 +1,10 @@
 #ifndef MINISHELL_H
 # define MINISHELL_H
 
+/* ************************************************************************** */
+/*                                INCLUDES                                    */
+/* ************************************************************************** */
+
 # include <stdlib.h>
 # include <stdio.h>
 # include <fcntl.h>
@@ -8,6 +12,10 @@
 # include <sys/wait.h>
 # include <signal.h>
 # include "libft.h"
+
+/* ************************************************************************** */
+/*                                  TYPES                                     */
+/* ************************************************************************** */
 
 typedef enum e_toktype
 {
@@ -19,6 +27,18 @@ typedef enum e_toktype
 	TOK_APPEND
 }	t_toktype;
 
+typedef enum e_err
+{
+	ERR_NONE,
+	ERR_MALLOC,
+	ERR_UNCLOSED_QUOTE,
+	ERR_SYNTAX
+}	t_err;
+
+/* ************************************************************************** */
+/*                                STRUCTURES                                  */
+/* ************************************************************************** */
+
 typedef struct s_token
 {
 	t_toktype		type;
@@ -26,17 +46,11 @@ typedef struct s_token
 	struct s_token	*next;
 }	t_token;
 
-typedef enum e_err
-{
-	ERR_NONE,
-	ERR_MALLOC,
-	ERR_UNCLOSED_QUOTE
-}	t_err;
-
 typedef struct s_redir
 {
 	t_toktype		type;
 	char			*target;
+	int				fd;
 	struct s_redir	*next;
 }	t_redir;
 
@@ -62,26 +76,81 @@ typedef struct s_tokctx
 	t_err		*err;
 }	t_tokctx;
 
+/* ************************************************************************** */
+/*                            TOKENIZATION                                    */
+/* ************************************************************************** */
+
 t_token	*tokenize_line(const char *line, t_shell *shell, t_err *err);
 t_token	*token_new(t_toktype type, char *value);
 void	token_add_back(t_token **lst, t_token *new_tok);
 void	free_tokens(t_token *lst);
-void	free_redirs(t_redir *list);
 int		try_add_token(t_token **head, char *word, t_err *err);
 int		add_op_token(t_token **head, t_toktype type, t_err *err);
 
+/* ************************************************************************** */
+/*                                PARSING                                     */
+/* ************************************************************************** */
+
 t_cmd	*parse_simple_cmd(t_token *tokens, t_err *err);
+void	free_argv(char **argv);
 void	free_cmd(t_cmd *cmd);
+
+/* ************************************************************************** */
+/*                              REDIRECTIONS                                  */
+/* ************************************************************************** */
+
+void	free_redirs(t_redir *list);
+int		is_redir_type(t_toktype type);
+int		add_redir_from_token(t_cmd *cmd, t_token *tok, t_err *err);
+
+/* ************************************************************************** */
+/*                              SHELL LOOP                                    */
+/* ************************************************************************** */
+
+int		main_loop(char **envp);
+int		run_once(const char *line, t_shell *shell);
+
+/* ************************************************************************** */
+/*                                SIGNALS                                     */
+/* ************************************************************************** */
 
 extern volatile sig_atomic_t	g_signal;
 
 void	setup_interactive_signals(void);
-int		main_loop(char **envp);
-int		run_once(const char *line, t_shell *shell);
+void	setup_heredoc_signals(void);
+void	setup_wait_signals(void);
+void	setup_child_signals(void);
+
+/* ************************************************************************** */
+/*                               EXECUTION                                    */
+/* ************************************************************************** */
 
 int		exec_simple_cmd(t_cmd *cmd, char **envp);
+int		exec_redir_only(t_cmd *cmd);
+int		wait_child(pid_t pid);
+int		apply_redirs(t_cmd *cmd, int *status);
+int		apply_one_redir(t_redir *r, int *in_fd,
+			int *out_fd, int *status);
+int		dup_and_close(int fd, int std_fd, int *status);
+void	close_redir_fds(int in_fd, int out_fd);
+int		prepare_redirs(t_cmd *cmd, int *status);
+int		setup_heredoc(const char *delim, int *fd, int *status);
 char	*find_in_path(const char *cmd, char **envp);
 int		ms_is_path(const char *cmd);
+
+/* ************************************************************************** */
+/*                                EXPANSION                                   */
+/* ************************************************************************** */
+
+int		ms_is_var_start(char c);
+int		ms_is_var_char(char c);
+char	*ms_getenv_value(const char *name, char **envp);
+char	*copy_env_value(char *name, t_shell *shell, t_err *err);
+char	*expand_env_vars(const char *str, t_shell *shell, t_err *err);
+
+/* ************************************************************************** */
+/*                                  UTILS                                     */
+/* ************************************************************************** */
 
 int		ms_isspace(char c);
 char	*ms_strjoin_free(char *s1, char *s2);
@@ -90,11 +159,5 @@ char	*read_word(const char *line, size_t *i,
 char	*read_single_quoted(const char *line, size_t *i, t_err *err);
 char	*read_double_quoted(const char *line, size_t *i,
 			t_shell *shell, t_err *err);
-
-int		ms_is_var_start(char c);
-int		ms_is_var_char(char c);
-char	*ms_getenv_value(const char *name, char **envp);
-char	*copy_env_value(char *name, t_shell *shell, t_err *err);
-char	*expand_env_vars(const char *str, t_shell *shell, t_err *err);
 
 #endif

--- a/src/builtins/builtin_cd.c
+++ b/src/builtins/builtin_cd.c
@@ -1,0 +1,90 @@
+#include "minishell.h"
+
+static int	set_pwd_entry(t_shell *shell, char *key, char *value)
+{
+	char	*entry;
+
+	entry = env_make_entry(key, value);
+	if (!entry)
+		return (1);
+	if (env_set_entry(shell, entry))
+	{
+		free(entry);
+		return (1);
+	}
+	free(entry);
+	return (0);
+}
+
+static int	update_pwd_vars(t_shell *shell, char *old_pwd)
+{
+	char	*new_pwd;
+
+	new_pwd = getcwd(NULL, 0);
+	if (!new_pwd)
+		return (1);
+	if (set_pwd_entry(shell, "OLDPWD", old_pwd)
+		|| set_pwd_entry(shell, "PWD", new_pwd))
+	{
+		free(new_pwd);
+		return (1);
+	}
+	free(new_pwd);
+	return (0);
+}
+
+static char	*get_cd_target(t_cmd *cmd, t_shell *shell)
+{
+	char	*home;
+
+	if (cmd->argc == 1)
+	{
+		home = ms_getenv_value("HOME", shell->envp);
+		if (!home || home[0] == '\0')
+		{
+			ft_putendl_fd("minishell: cd: HOME not set", STDERR_FILENO);
+			return (NULL);
+		}
+		return (home);
+	}
+	return (cmd->argv[1]);
+}
+
+static int	change_dir(char *target, char **old_pwd)
+{
+	*old_pwd = getcwd(NULL, 0);
+	if (!*old_pwd)
+		return (1);
+	if (chdir(target) != 0)
+	{
+		free(*old_pwd);
+		ft_putstr_fd("minishell: cd: ", STDERR_FILENO);
+		perror(target);
+		return (1);
+	}
+	return (0);
+}
+
+int	builtin_cd(t_cmd *cmd, t_shell *shell)
+{
+	char	*target;
+	char	*old_pwd;
+
+	if (cmd->argc > 2)
+	{
+		ft_putendl_fd("minishell: cd: too many arguments", STDERR_FILENO);
+		return (1);
+	}
+	target = get_cd_target(cmd, shell);
+	if (!target)
+		return (1);
+	if (change_dir(target, &old_pwd))
+		return (1);
+	if (update_pwd_vars(shell, old_pwd))
+	{
+		free(old_pwd);
+		return (1);
+	}
+	free(old_pwd);
+	return (0);
+}

--- a/src/builtins/builtin_dispatch.c
+++ b/src/builtins/builtin_dispatch.c
@@ -23,6 +23,8 @@ int	exec_builtin(t_cmd *cmd, t_shell *shell)
 		return (builtin_pwd());
 	if (ft_strncmp(cmd->argv[0], "env", 4) == 0)
 		return (builtin_env(shell));
+	if (ft_strncmp(cmd->argv[0], "export", 7) == 0)
+		return (builtin_export(cmd, shell));
 	ft_putstr_fd("minishell: ", STDERR_FILENO);
 	ft_putstr_fd(cmd->argv[0], STDERR_FILENO);
 	ft_putendl_fd(": builtin not implemented yet", STDERR_FILENO);

--- a/src/builtins/builtin_dispatch.c
+++ b/src/builtins/builtin_dispatch.c
@@ -27,6 +27,8 @@ int	exec_builtin(t_cmd *cmd, t_shell *shell)
 		return (builtin_export(cmd, shell));
 	if (ft_strncmp(cmd->argv[0], "unset", 6) == 0)
 		return (builtin_unset(cmd, shell));
+	if (ft_strncmp(cmd->argv[0], "cd", 3) == 0)
+		return (builtin_cd(cmd, shell));
 	ft_putstr_fd("minishell: ", STDERR_FILENO);
 	ft_putstr_fd(cmd->argv[0], STDERR_FILENO);
 	ft_putendl_fd(": builtin not implemented yet", STDERR_FILENO);

--- a/src/builtins/builtin_dispatch.c
+++ b/src/builtins/builtin_dispatch.c
@@ -1,0 +1,30 @@
+#include "minishell.h"
+
+static int	str_eq(const char *s1, const char *s2)
+{
+	return (ft_strncmp(s1, s2, ft_strlen(s2) + 1) == 0);
+}
+
+int	is_builtin(const char *cmd)
+{
+	if (!cmd)
+		return (0);
+	return (str_eq(cmd, "echo") || str_eq(cmd, "pwd")
+		|| str_eq(cmd, "env") || str_eq(cmd, "cd")
+		|| str_eq(cmd, "export") || str_eq(cmd, "unset")
+		|| str_eq(cmd, "exit"));
+}
+
+int	exec_builtin(t_cmd *cmd, t_shell *shell)
+{
+	if (ft_strncmp(cmd->argv[0], "echo", 5) == 0)
+		return (builtin_echo(cmd));
+	if (ft_strncmp(cmd->argv[0], "pwd", 4) == 0)
+		return (builtin_pwd());
+	if (ft_strncmp(cmd->argv[0], "env", 4) == 0)
+		return (builtin_env(shell));
+	ft_putstr_fd("minishell: ", STDERR_FILENO);
+	ft_putstr_fd(cmd->argv[0], STDERR_FILENO);
+	ft_putendl_fd(": builtin not implemented yet", STDERR_FILENO);
+	return (1);
+}

--- a/src/builtins/builtin_dispatch.c
+++ b/src/builtins/builtin_dispatch.c
@@ -29,6 +29,8 @@ int	exec_builtin(t_cmd *cmd, t_shell *shell)
 		return (builtin_unset(cmd, shell));
 	if (ft_strncmp(cmd->argv[0], "cd", 3) == 0)
 		return (builtin_cd(cmd, shell));
+	if (ft_strncmp(cmd->argv[0], "exit", 5) == 0)
+		return (builtin_exit(cmd, shell));
 	ft_putstr_fd("minishell: ", STDERR_FILENO);
 	ft_putstr_fd(cmd->argv[0], STDERR_FILENO);
 	ft_putendl_fd(": builtin not implemented yet", STDERR_FILENO);

--- a/src/builtins/builtin_dispatch.c
+++ b/src/builtins/builtin_dispatch.c
@@ -25,6 +25,8 @@ int	exec_builtin(t_cmd *cmd, t_shell *shell)
 		return (builtin_env(shell));
 	if (ft_strncmp(cmd->argv[0], "export", 7) == 0)
 		return (builtin_export(cmd, shell));
+	if (ft_strncmp(cmd->argv[0], "unset", 6) == 0)
+		return (builtin_unset(cmd, shell));
 	ft_putstr_fd("minishell: ", STDERR_FILENO);
 	ft_putstr_fd(cmd->argv[0], STDERR_FILENO);
 	ft_putendl_fd(": builtin not implemented yet", STDERR_FILENO);

--- a/src/builtins/builtin_echo.c
+++ b/src/builtins/builtin_echo.c
@@ -1,0 +1,37 @@
+#include "minishell.h"
+
+static int	is_n_option(const char *arg)
+{
+	int	i;
+
+	if (!arg || arg[0] != '-' || arg[1] != 'n')
+		return (0);
+	i = 2;
+	while (arg[i] == 'n')
+		i++;
+	return (arg[i] == '\0');
+}
+
+int	builtin_echo(t_cmd *cmd)
+{
+	int	i;
+	int	newline;
+
+	i = 1;
+	newline = 1;
+	while (cmd->argv[i] && is_n_option(cmd->argv[i]))
+	{
+		newline = 0;
+		i++;
+	}
+	while (cmd->argv[i])
+	{
+		ft_putstr_fd(cmd->argv[i], STDOUT_FILENO);
+		if (cmd->argv[i + 1])
+			ft_putchar_fd(' ', STDOUT_FILENO);
+		i++;
+	}
+	if (newline)
+		ft_putchar_fd('\n', STDOUT_FILENO);
+	return (0);
+}

--- a/src/builtins/builtin_env.c
+++ b/src/builtins/builtin_env.c
@@ -1,0 +1,14 @@
+#include "minishell.h"
+
+int	builtin_env(t_shell *shell)
+{
+	int	i;
+
+	i = 0;
+	while (shell->envp && shell->envp[i])
+	{
+		ft_putendl_fd(shell->envp[i], STDOUT_FILENO);
+		i++;
+	}
+	return (0);
+}

--- a/src/builtins/builtin_exit.c
+++ b/src/builtins/builtin_exit.c
@@ -1,0 +1,38 @@
+#include "minishell.h"
+
+static int	exit_status(long long value)
+{
+	return ((unsigned char)value);
+}
+
+static int	print_numeric_error(char *arg)
+{
+	ft_putstr_fd("minishell: exit: ", STDERR_FILENO);
+	ft_putstr_fd(arg, STDERR_FILENO);
+	ft_putendl_fd(": numeric argument required", STDERR_FILENO);
+	return (2);
+}
+
+int	builtin_exit(t_cmd *cmd, t_shell *shell)
+{
+	long long	value;
+
+	ft_putendl_fd("exit", STDERR_FILENO);
+	if (cmd->argc == 1)
+	{
+		shell->should_exit = 1;
+		return (shell->last_status);
+	}
+	if (!parse_exit_number(cmd->argv[1], &value))
+	{
+		shell->should_exit = 1;
+		return (print_numeric_error(cmd->argv[1]));
+	}
+	if (cmd->argc > 2)
+	{
+		ft_putendl_fd("minishell: exit: too many arguments", STDERR_FILENO);
+		return (1);
+	}
+	shell->should_exit = 1;
+	return (exit_status(value));
+}

--- a/src/builtins/builtin_exit_utils.c
+++ b/src/builtins/builtin_exit_utils.c
@@ -1,0 +1,60 @@
+#include "minishell.h"
+
+static int	parse_sign(const char *str, int *i)
+{
+	int	sign;
+
+	sign = 1;
+	if (str[*i] == '-' || str[*i] == '+')
+	{
+		if (str[*i] == '-')
+			sign = -1;
+		(*i)++;
+	}
+	return (sign);
+}
+
+static int	add_digit(unsigned long long *num, char c, int sign)
+{
+	unsigned long long	limit;
+	unsigned long long	digit;
+
+	if (sign < 0)
+		limit = 9223372036854775808ULL;
+	else
+		limit = 9223372036854775807ULL;
+	digit = c - '0';
+	if (*num > limit / 10)
+		return (0);
+	if (*num == limit / 10 && digit > limit % 10)
+		return (0);
+	*num = (*num * 10) + digit;
+	return (1);
+}
+
+int	parse_exit_number(const char *str, long long *value)
+{
+	unsigned long long	num;
+	int					i;
+	int					sign;
+
+	i = 0;
+	num = 0;
+	while (ms_isspace(str[i]))
+		i++;
+	sign = parse_sign(str, &i);
+	if (!ft_isdigit(str[i]))
+		return (0);
+	while (ft_isdigit(str[i]))
+	{
+		if (!add_digit(&num, str[i], sign))
+			return (0);
+		i++;
+	}
+	while (ms_isspace(str[i]))
+		i++;
+	if (str[i] != '\0')
+		return (0);
+	*value = (long long)(num * sign);
+	return (1);
+}

--- a/src/builtins/builtin_export.c
+++ b/src/builtins/builtin_export.c
@@ -1,0 +1,61 @@
+#include "minishell.h"
+
+static int	is_valid_identifier(const char *arg)
+{
+	int	i;
+
+	if (!arg || (!ft_isalpha(arg[0]) && arg[0] != '_'))
+		return (0);
+	i = 1;
+	while (arg[i] && arg[i] != '=')
+	{
+		if (!ft_isalnum(arg[i]) && arg[i] != '_')
+			return (0);
+		i++;
+	}
+	return (1);
+}
+
+static void	print_export_error(const char *arg)
+{
+	ft_putstr_fd("minishell: export: `", STDERR_FILENO);
+	ft_putstr_fd((char *)arg, STDERR_FILENO);
+	ft_putendl_fd("': not a valid identifier", STDERR_FILENO);
+}
+
+static int	print_export(char **envp)
+{
+	int	i;
+
+	i = 0;
+	while (envp && envp[i])
+	{
+		ft_putstr_fd("declare -x ", STDOUT_FILENO);
+		ft_putendl_fd(envp[i], STDOUT_FILENO);
+		i++;
+	}
+	return (0);
+}
+
+int	builtin_export(t_cmd *cmd, t_shell *shell)
+{
+	int	i;
+	int	status;
+
+	if (cmd->argc == 1)
+		return (print_export(shell->envp));
+	status = 0;
+	i = 1;
+	while (cmd->argv[i])
+	{
+		if (!is_valid_identifier(cmd->argv[i]))
+		{
+			print_export_error(cmd->argv[i]);
+			status = 1;
+		}
+		else if (env_set_entry(shell, cmd->argv[i]))
+			return (1);
+		i++;
+	}
+	return (status);
+}

--- a/src/builtins/builtin_parent.c
+++ b/src/builtins/builtin_parent.c
@@ -1,0 +1,59 @@
+#include "minishell.h"
+
+static int	save_std_fds(int *stdin_save, int *stdout_save)
+{
+	*stdin_save = dup(STDIN_FILENO);
+	*stdout_save = dup(STDOUT_FILENO);
+	if (*stdin_save < 0 || *stdout_save < 0)
+	{
+		if (*stdin_save != -1)
+			close(*stdin_save);
+		if (*stdout_save != -1)
+			close(*stdout_save);
+		perror("dup");
+		return (1);
+	}
+	return (0);
+}
+
+static int	restore_std_fds(int stdin_save, int stdout_save)
+{
+	int	status;
+
+	status = 0;
+	if (dup2(stdin_save, STDIN_FILENO) < 0)
+	{
+		perror("dup2");
+		status = 1;
+	}
+	if (dup2(stdout_save, STDOUT_FILENO) < 0)
+	{
+		perror("dup2");
+		status = 1;
+	}
+	close(stdin_save);
+	close(stdout_save);
+	return (status);
+}
+
+int	exec_builtin_parent(t_cmd *cmd, t_shell *shell)
+{
+	int	stdin_save;
+	int	stdout_save;
+	int	status;
+
+	status = 0;
+	stdin_save = -1;
+	stdout_save = -1;
+	if (save_std_fds(&stdin_save, &stdout_save))
+		return (1);
+	if (apply_redirs(cmd, &status))
+	{
+		restore_std_fds(stdin_save, stdout_save);
+		return (status);
+	}
+	status = exec_builtin(cmd, shell);
+	if (restore_std_fds(stdin_save, stdout_save))
+		return (1);
+	return (status);
+}

--- a/src/builtins/builtin_pwd.c
+++ b/src/builtins/builtin_pwd.c
@@ -1,0 +1,16 @@
+#include "minishell.h"
+
+int	builtin_pwd(void)
+{
+	char	*cwd;
+
+	cwd = getcwd(NULL, 0);
+	if (!cwd)
+	{
+		perror("pwd");
+		return (1);
+	}
+	ft_putendl_fd(cwd, STDOUT_FILENO);
+	free(cwd);
+	return (0);
+}

--- a/src/builtins/builtin_unset.c
+++ b/src/builtins/builtin_unset.c
@@ -1,0 +1,45 @@
+#include "minishell.h"
+
+static int	is_valid_identifier(const char *arg)
+{
+	int	i;
+
+	if (!arg || (!ft_isalpha(arg[0]) && arg[0] != '_'))
+		return (0);
+	i = 1;
+	while (arg[i])
+	{
+		if (!ft_isalnum(arg[i]) && arg[i] != '_')
+			return (0);
+		i++;
+	}
+	return (1);
+}
+
+static void	print_unset_error(const char *arg)
+{
+	ft_putstr_fd("minishell: unset: `", STDERR_FILENO);
+	ft_putstr_fd((char *)arg, STDERR_FILENO);
+	ft_putendl_fd("': not a valid identifier", STDERR_FILENO);
+}
+
+int	builtin_unset(t_cmd *cmd, t_shell *shell)
+{
+	int	i;
+	int	status;
+
+	status = 0;
+	i = 1;
+	while (cmd->argv[i])
+	{
+		if (!is_valid_identifier(cmd->argv[i]))
+		{
+			print_unset_error(cmd->argv[i]);
+			status = 1;
+		}
+		else if (env_unset_entry(shell, cmd->argv[i]))
+			return (1);
+		i++;
+	}
+	return (status);
+}

--- a/src/env/env_copy.c
+++ b/src/env/env_copy.c
@@ -1,0 +1,35 @@
+#include "minishell.h"
+
+static int	env_count(char **envp)
+{
+	int	count;
+
+	count = 0;
+	while (envp && envp[count])
+		count++;
+	return (count);
+}
+
+char	**env_dup(char **envp)
+{
+	char	**copy;
+	int		count;
+	int		i;
+
+	count = env_count(envp);
+	copy = ft_calloc(count + 1, sizeof(char *));
+	if (!copy)
+		return (NULL);
+	i = 0;
+	while (i < count)
+	{
+		copy[i] = ft_substr(envp[i], 0, ft_strlen(envp[i]));
+		if (!copy[i])
+		{
+			free_argv(copy);
+			return (NULL);
+		}
+		i++;
+	}
+	return (copy);
+}

--- a/src/env/env_entry.c
+++ b/src/env/env_entry.c
@@ -1,0 +1,14 @@
+#include "minishell.h"
+
+char	*env_make_entry(const char *key, const char *value)
+{
+	char	*prefix;
+	char	*entry;
+
+	prefix = ft_strjoin(key, "=");
+	if (!prefix)
+		return (NULL);
+	entry = ft_strjoin(prefix, value);
+	free(prefix);
+	return (entry);
+}

--- a/src/env/env_set.c
+++ b/src/env/env_set.c
@@ -1,0 +1,80 @@
+#include "minishell.h"
+
+static int	env_count(char **envp)
+{
+	int	count;
+
+	count = 0;
+	while (envp && envp[count])
+		count++;
+	return (count);
+}
+
+static int	has_equal(const char *entry)
+{
+	int	i;
+
+	i = 0;
+	while (entry[i])
+	{
+		if (entry[i] == '=')
+			return (1);
+		i++;
+	}
+	return (0);
+}
+
+static int	env_replace(char **envp, int index, const char *entry)
+{
+	char	*copy;
+
+	copy = ft_substr(entry, 0, ft_strlen(entry));
+	if (!copy)
+		return (1);
+	free(envp[index]);
+	envp[index] = copy;
+	return (0);
+}
+
+static char	**env_new_with_entry(char **envp, const char *entry)
+{
+	char	**new_env;
+	int		count;
+	int		i;
+
+	count = env_count(envp);
+	new_env = ft_calloc(count + 2, sizeof(char *));
+	if (!new_env)
+		return (NULL);
+	i = 0;
+	while (i < count)
+	{
+		new_env[i] = envp[i];
+		i++;
+	}
+	new_env[i] = ft_substr(entry, 0, ft_strlen(entry));
+	if (!new_env[i])
+	{
+		free(new_env);
+		return (NULL);
+	}
+	return (new_env);
+}
+
+int	env_set_entry(t_shell *shell, const char *entry)
+{
+	char	**new_env;
+	int		index;
+
+	index = env_find_index(shell->envp, entry);
+	if (index >= 0 && !has_equal(entry))
+		return (0);
+	if (index >= 0)
+		return (env_replace(shell->envp, index, entry));
+	new_env = env_new_with_entry(shell->envp, entry);
+	if (!new_env)
+		return (1);
+	free(shell->envp);
+	shell->envp = new_env;
+	return (0);
+}

--- a/src/env/env_unset.c
+++ b/src/env/env_unset.c
@@ -1,0 +1,50 @@
+#include "minishell.h"
+
+static int	env_count(char **envp)
+{
+	int	count;
+
+	count = 0;
+	while (envp && envp[count])
+		count++;
+	return (count);
+}
+
+static char	**env_without_index(char **envp, int remove_index)
+{
+	char	**new_env;
+	int		count;
+	int		i;
+	int		j;
+
+	count = env_count(envp);
+	new_env = ft_calloc(count, sizeof(char *));
+	if (!new_env)
+		return (NULL);
+	i = 0;
+	j = 0;
+	while (i < count)
+	{
+		if (i != remove_index)
+			new_env[j++] = envp[i];
+		i++;
+	}
+	return (new_env);
+}
+
+int	env_unset_entry(t_shell *shell, const char *name)
+{
+	char	**new_env;
+	int		index;
+
+	index = env_find_index(shell->envp, name);
+	if (index < 0)
+		return (0);
+	new_env = env_without_index(shell->envp, index);
+	if (!new_env)
+		return (1);
+	free(shell->envp[index]);
+	free(shell->envp);
+	shell->envp = new_env;
+	return (0);
+}

--- a/src/env/env_utils.c
+++ b/src/env/env_utils.c
@@ -1,0 +1,32 @@
+#include "minishell.h"
+
+static size_t	env_name_len(const char *entry)
+{
+	size_t	i;
+
+	i = 0;
+	while (entry[i] && entry[i] != '=')
+		i++;
+	return (i);
+}
+
+int	env_find_index(char **envp, const char *name)
+{
+	size_t	name_len;
+	size_t	entry_len;
+	int		i;
+
+	if (!envp || !name)
+		return (-1);
+	name_len = env_name_len(name);
+	i = 0;
+	while (envp[i])
+	{
+		entry_len = env_name_len(envp[i]);
+		if (entry_len == name_len
+			&& ft_strncmp(envp[i], name, name_len) == 0)
+			return (i);
+		i++;
+	}
+	return (-1);
+}

--- a/src/exec/exec_heredoc.c
+++ b/src/exec/exec_heredoc.c
@@ -1,0 +1,88 @@
+#include "minishell.h"
+
+static int	is_delim(const char *line, const char *delim)
+{
+	size_t	len;
+
+	len = ft_strlen(delim);
+	if (ft_strlen(line) != len)
+		return (0);
+	return (ft_strncmp(line, delim, len) == 0);
+}
+
+static char	*append_char(char *line, char c)
+{
+	char	buf[2];
+	char	*tmp;
+
+	buf[0] = c;
+	buf[1] = '\0';
+	tmp = ms_strjoin_free(line, buf);
+	return (tmp);
+}
+
+static char	*read_heredoc_line(void)
+{
+	char	*line;
+	char	c;
+	int		ret;
+
+	line = ft_calloc(1, sizeof(char));
+	if (!line)
+		return (NULL);
+	while (g_signal != SIGINT)
+	{
+		ret = read(STDIN_FILENO, &c, 1);
+		if (ret <= 0 || c == '\n')
+			break ;
+		line = append_char(line, c);
+		if (!line)
+			return (NULL);
+	}
+	return (line);
+}
+
+static int	read_heredoc_lines(int write_fd, const char *delim)
+{
+	char	*line;
+
+	while (g_signal != SIGINT)
+	{
+		write(STDOUT_FILENO, "> ", 2);
+		line = read_heredoc_line();
+		if (!line)
+			break ;
+		if (is_delim(line, delim))
+		{
+			free(line);
+			break ;
+		}
+		write(write_fd, line, ft_strlen(line));
+		write(write_fd, "\n", 1);
+		free(line);
+	}
+	return (g_signal == SIGINT);
+}
+
+int	setup_heredoc(const char *delim, int *fd, int *status)
+{
+	int	pipefd[2];
+
+	if (pipe(pipefd) < 0)
+	{
+		perror("pipe");
+		*status = 1;
+		return (1);
+	}
+	setup_heredoc_signals();
+	if (read_heredoc_lines(pipefd[1], delim))
+	{
+		close_redir_fds(pipefd[0], pipefd[1]);
+		*fd = -1;
+		*status = 130;
+		return (1);
+	}
+	close(pipefd[1]);
+	*fd = pipefd[0];
+	return (0);
+}

--- a/src/exec/exec_redir_one.c
+++ b/src/exec/exec_redir_one.c
@@ -1,0 +1,32 @@
+#include "minishell.h"
+
+static void	set_redir_fd(t_redir *r, int *in_fd, int *out_fd, int fd)
+{
+	if (r->type == TOK_REDIR_IN || r->type == TOK_HEREDOC)
+	{
+		if (*in_fd != -1)
+			close(*in_fd);
+		*in_fd = fd;
+	}
+	else
+	{
+		if (*out_fd != -1)
+			close(*out_fd);
+		*out_fd = fd;
+	}
+}
+
+int	apply_one_redir(t_redir *r, int *in_fd, int *out_fd, int *status)
+{
+	int	fd;
+
+	fd = r->fd;
+	r->fd = -1;
+	if (fd < 0)
+	{
+		*status = 1;
+		return (1);
+	}
+	set_redir_fd(r, in_fd, out_fd, fd);
+	return (0);
+}

--- a/src/exec/exec_redir_only.c
+++ b/src/exec/exec_redir_only.c
@@ -1,0 +1,58 @@
+#include "minishell.h"
+
+static int	save_std_fds(int *stdin_save, int *stdout_save)
+{
+	*stdin_save = dup(STDIN_FILENO);
+	*stdout_save = dup(STDOUT_FILENO);
+	if (*stdin_save < 0 || *stdout_save < 0)
+	{
+		if (*stdin_save != -1)
+			close(*stdin_save);
+		if (*stdout_save != -1)
+			close(*stdout_save);
+		perror("dup");
+		return (1);
+	}
+	return (0);
+}
+
+static int	restore_std_fds(int stdin_save, int stdout_save)
+{
+	int	status;
+
+	status = 0;
+	if (dup2(stdin_save, STDIN_FILENO) < 0)
+	{
+		perror("dup2");
+		status = 1;
+	}
+	if (dup2(stdout_save, STDOUT_FILENO) < 0)
+	{
+		perror("dup2");
+		status = 1;
+	}
+	close(stdin_save);
+	close(stdout_save);
+	return (status);
+}
+
+int	exec_redir_only(t_cmd *cmd)
+{
+	int	stdin_save;
+	int	stdout_save;
+	int	status;
+
+	status = 0;
+	stdin_save = -1;
+	stdout_save = -1;
+	if (save_std_fds(&stdin_save, &stdout_save))
+		return (1);
+	if (apply_redirs(cmd, &status))
+	{
+		restore_std_fds(stdin_save, stdout_save);
+		return (status);
+	}
+	if (restore_std_fds(stdin_save, stdout_save))
+		return (1);
+	return (status);
+}

--- a/src/exec/exec_redir_prepare.c
+++ b/src/exec/exec_redir_prepare.c
@@ -1,0 +1,70 @@
+#include "minishell.h"
+
+static int	open_input(const char *path, int *fd, int *status)
+{
+	*fd = open(path, O_RDONLY);
+	if (*fd < 0)
+	{
+		perror(path);
+		*status = 1;
+		return (1);
+	}
+	return (0);
+}
+
+static int	open_output(const char *path, int flags, int *fd, int *status)
+{
+	*fd = open(path, flags, 0644);
+	if (*fd < 0)
+	{
+		perror(path);
+		*status = 1;
+		return (1);
+	}
+	return (0);
+}
+
+static int	prepare_one_redir(t_redir *r, int *status)
+{
+	int	fd;
+
+	fd = -1;
+	if (r->type == TOK_REDIR_IN && open_input(r->target, &fd, status))
+		return (1);
+	else if (r->type == TOK_REDIR_OUT
+		&& open_output(r->target, O_WRONLY | O_CREAT | O_TRUNC, &fd, status))
+		return (1);
+	else if (r->type == TOK_APPEND
+		&& open_output(r->target, O_WRONLY | O_CREAT | O_APPEND, &fd, status))
+		return (1);
+	else if (r->type == TOK_HEREDOC && setup_heredoc(r->target, &fd, status))
+		return (1);
+	if (r->fd != -1)
+		close(r->fd);
+	r->fd = fd;
+	return (0);
+}
+
+int	prepare_redirs(t_cmd *cmd, int *status)
+{
+	t_redir	*r;
+	int		had_heredoc;
+
+	had_heredoc = 0;
+	r = cmd->redirs;
+	while (r)
+	{
+		if (r->type == TOK_HEREDOC)
+			had_heredoc = 1;
+		if (prepare_one_redir(r, status))
+		{
+			if (had_heredoc)
+				setup_interactive_signals();
+			return (1);
+		}
+		r = r->next;
+	}
+	if (had_heredoc)
+		setup_interactive_signals();
+	return (0);
+}

--- a/src/exec/exec_redirs.c
+++ b/src/exec/exec_redirs.c
@@ -1,0 +1,53 @@
+#include "minishell.h"
+
+int	dup_and_close(int fd, int std_fd, int *status)
+{
+	if (dup2(fd, std_fd) < 0)
+	{
+		perror("dup2");
+		close(fd);
+		*status = 1;
+		return (1);
+	}
+	close(fd);
+	return (0);
+}
+
+void	close_redir_fds(int in_fd, int out_fd)
+{
+	if (in_fd != -1)
+		close(in_fd);
+	if (out_fd != -1)
+		close(out_fd);
+}
+
+static int	apply_all_redirs(t_redir *r, int *in_fd,
+	int *out_fd, int *status)
+{
+	while (r)
+	{
+		if (apply_one_redir(r, in_fd, out_fd, status))
+		{
+			close_redir_fds(*in_fd, *out_fd);
+			return (1);
+		}
+		r = r->next;
+	}
+	return (0);
+}
+
+int	apply_redirs(t_cmd *cmd, int *status)
+{
+	int	in_fd;
+	int	out_fd;
+
+	in_fd = -1;
+	out_fd = -1;
+	if (apply_all_redirs(cmd->redirs, &in_fd, &out_fd, status))
+		return (1);
+	if (in_fd != -1 && dup_and_close(in_fd, STDIN_FILENO, status))
+		return (1);
+	if (out_fd != -1 && dup_and_close(out_fd, STDOUT_FILENO, status))
+		return (1);
+	return (0);
+}

--- a/src/exec/exec_simple.c
+++ b/src/exec/exec_simple.c
@@ -30,7 +30,7 @@ static void	exec_from_path(t_cmd *cmd, char **envp)
 	_exit(126);
 }
 
-static void	exec_child(t_cmd *cmd, char **envp)
+static void	exec_child(t_cmd *cmd, t_shell *shell)
 {
 	int	status;
 
@@ -39,13 +39,15 @@ static void	exec_child(t_cmd *cmd, char **envp)
 		_exit(status);
 	if (cmd->argc == 0)
 		_exit(0);
+	if (is_builtin(cmd->argv[0]))
+		_exit(exec_builtin(cmd, shell));
 	if (ms_is_path(cmd->argv[0]))
-		exec_path_cmd(cmd, envp);
+		exec_path_cmd(cmd, shell->envp);
 	else
-		exec_from_path(cmd, envp);
+		exec_from_path(cmd, shell->envp);
 }
 
-int	exec_simple_cmd(t_cmd *cmd, char **envp)
+int	exec_simple_cmd(t_cmd *cmd, t_shell *shell)
 {
 	pid_t	pid;
 	int		status;
@@ -63,7 +65,7 @@ int	exec_simple_cmd(t_cmd *cmd, char **envp)
 	if (pid == 0)
 	{
 		setup_child_signals();
-		exec_child(cmd, envp);
+		exec_child(cmd, shell);
 	}
 	return (wait_child(pid));
 }

--- a/src/exec/exec_simple.c
+++ b/src/exec/exec_simple.c
@@ -59,6 +59,8 @@ int	exec_simple_cmd(t_cmd *cmd, t_shell *shell)
 		return (status);
 	if (cmd->argc == 0)
 		return (exec_redir_only(cmd));
+	if (is_builtin(cmd->argv[0]))
+		return (exec_builtin_parent(cmd, shell));
 	pid = fork();
 	if (pid < 0)
 		return (1);

--- a/src/exec/exec_simple.c
+++ b/src/exec/exec_simple.c
@@ -1,167 +1,69 @@
 #include "minishell.h"
-#include <readline/readline.h>
 
-static int	open_input(const char *path, int *fd, int *status)
+static void	print_cmd_error(const char *cmd, const char *msg)
 {
-	*fd = open(path, O_RDONLY);
-	if (*fd < 0)
-	{
-		perror(path);
-		*status = 1;
-		return (1);
-	}
-	return (0);
+	ft_putstr_fd("minishell: ", STDERR_FILENO);
+	ft_putstr_fd((char *)cmd, STDERR_FILENO);
+	ft_putendl_fd((char *)msg, STDERR_FILENO);
 }
 
-static int	open_output(const char *path, int flags, int *fd, int *status)
+static void	exec_path_cmd(t_cmd *cmd, char **envp)
 {
-	*fd = open(path, flags, 0644);
-	if (*fd < 0)
-	{
-		perror(path);
-		*status = 1;
-		return (1);
-	}
-	return (0);
-}
-static int	is_delim(const char *line, const char *delim)
-{
-	size_t	len;
-
-	len = ft_strlen(delim);
-	if (ft_strlen(line) != len)
-		return (0);
-	return (ft_strncmp(line, delim, len) == 0);
+	execve(cmd->argv[0], cmd->argv, envp);
+	perror("minishell");
+	_exit(1);
 }
 
-static int	setup_heredoc(const char *delim, int *fd, int *status)
+static void	exec_from_path(t_cmd *cmd, char **envp)
 {
-	int		pipefd[2];
-	char	*line;
+	char	*path;
 
-	if (pipe(pipefd) < 0)
+	path = find_in_path(cmd->argv[0], envp);
+	if (!path)
 	{
-		perror("pipe");
-		*status = 1;
-		return (1);
+		print_cmd_error(cmd->argv[0], ": command not found");
+		_exit(127);
 	}
-	while (1)
-	{
-		line = readline("> ");
-		if (!line)
-			break ;
-		if (is_delim(line, delim))
-		{
-			free(line);
-			break ;
-		}
-		write(pipefd[1], line, ft_strlen(line));
-		write(pipefd[1], "\n", 1);
-		free(line);
-	}
-	close(pipefd[1]);
-	*fd = pipefd[0];
-	return (0);
+	execve(path, cmd->argv, envp);
+	print_cmd_error(path, ": cannot execute");
+	free(path);
+	_exit(126);
 }
 
-static int	apply_redirs(t_cmd *cmd, int *status)
+static void	exec_child(t_cmd *cmd, char **envp)
 {
-	t_redir	*r;
-	int		in_fd;
-	int		out_fd;
+	int	status;
 
-	in_fd = -1;
-	out_fd = -1;
-	r = cmd->redirs;
-	while (r)
-	{
-		if (r->type == TOK_REDIR_IN)
-		{
-			if (open_input(r->target, &in_fd, status))
-				return (1);
-		}
-		else if (r->type == TOK_REDIR_OUT)
-		{
-			if (open_output(r->target,
-					O_WRONLY | O_CREAT | O_TRUNC, &out_fd, status))
-				return (1);
-		}
-		else if (r->type == TOK_APPEND)
-		{
-			if (open_output(r->target,
-					O_WRONLY | O_CREAT | O_APPEND, &out_fd, status))
-				return (1);
-		}
-		else if (r->type == TOK_HEREDOC)
-		{
-			if (setup_heredoc(r->target, &in_fd, status))
-				return (1);
-		}
-		r = r->next;
-	}
-	if (in_fd != -1)
-	{
-		if (dup2(in_fd, STDIN_FILENO) < 0)
-		{
-			perror("dup2");
-			*status = 1;
-			return (1);
-		}
-		close(in_fd);
-	}
-	if (out_fd != -1)
-	{
-		if (dup2(out_fd, STDOUT_FILENO) < 0)
-		{
-			perror("dup2");
-			*status = 1;
-			return (1);
-		}
-		close(out_fd);
-	}
-	return (0);
+	status = 0;
+	if (apply_redirs(cmd, &status))
+		_exit(status);
+	if (cmd->argc == 0)
+		_exit(0);
+	if (ms_is_path(cmd->argv[0]))
+		exec_path_cmd(cmd, envp);
+	else
+		exec_from_path(cmd, envp);
 }
 
 int	exec_simple_cmd(t_cmd *cmd, char **envp)
 {
 	pid_t	pid;
 	int		status;
-	char	*path;
 
-	if (!cmd || cmd->argc == 0)
+	if (!cmd)
 		return (0);
+	status = 0;
+	if (prepare_redirs(cmd, &status))
+		return (status);
+	if (cmd->argc == 0)
+		return (exec_redir_only(cmd));
 	pid = fork();
 	if (pid < 0)
 		return (1);
 	if (pid == 0)
 	{
-		status = 0;
-		if (apply_redirs(cmd, &status))
-			_exit(status);
-		if (ms_is_path(cmd->argv[0]))
-			execve(cmd->argv[0], cmd->argv, envp);
-		else
-		{
-			path = find_in_path(cmd->argv[0], envp);
-			if (!path)
-			{
-				fprintf(stderr, "minishell: %s: command not found\n",
-					cmd->argv[0]);
-				_exit(127);
-			}
-			execve(path, cmd->argv, envp);
-			fprintf(stderr, "minishell: %s: cannot execute\n", path);
-			free(path);
-			_exit(126);
-		}
-		perror("minishell");
-		_exit(1);
+		setup_child_signals();
+		exec_child(cmd, envp);
 	}
-	if (waitpid(pid, &status, 0) < 0)
-		return (1);
-	if (WIFEXITED(status))
-		return (WEXITSTATUS(status));
-	if (WIFSIGNALED(status))
-		return (128 + WTERMSIG(status));
-	return (1);
+	return (wait_child(pid));
 }

--- a/src/exec/exec_wait.c
+++ b/src/exec/exec_wait.c
@@ -1,0 +1,19 @@
+#include "minishell.h"
+
+int	wait_child(pid_t pid)
+{
+	int	status;
+
+	setup_wait_signals();
+	if (waitpid(pid, &status, 0) < 0)
+	{
+		setup_interactive_signals();
+		return (1);
+	}
+	setup_interactive_signals();
+	if (WIFEXITED(status))
+		return (WEXITSTATUS(status));
+	if (WIFSIGNALED(status))
+		return (128 + WTERMSIG(status));
+	return (1);
+}

--- a/src/parsing/cmd.c
+++ b/src/parsing/cmd.c
@@ -7,75 +7,37 @@ static int	count_args(t_token *tok)
 	count = 0;
 	while (tok)
 	{
-		if (tok->type == TOK_WORD)
+		if (is_redir_type(tok->type))
+		{
+			if (tok->next)
+				tok = tok->next;
+		}
+		else if (tok->type == TOK_WORD)
 			count++;
 		tok = tok->next;
 	}
 	return (count);
 }
 
-static void	free_argv(char **argv, int count)
+static int	add_word_arg(char **argv, int *i, t_token *tok, t_err *err)
 {
-	int	i;
-
-	if (!argv)
-		return ;
-	i = 0;
-	while (i < count)
-	{
-		free(argv[i]);
-		i++;
-	}
-	free(argv);
-}
-
-void	free_redirs(t_redir *list)
-{
-	t_redir	*next;
-
-	while (list)
-	{
-		next = list->next;
-		free(list->target);
-		free(list);
-		list = next;
-	}
-}
-
-static int	add_redir(t_cmd *cmd, t_toktype type, char *target, t_err *err)
-{
-	t_redir	*node;
-	t_redir	*cur;
-
-	node = malloc(sizeof(t_redir));
-	if (!node)
+	argv[*i] = ft_substr(tok->value, 0, ft_strlen(tok->value));
+	if (!argv[*i])
 	{
 		*err = ERR_MALLOC;
-		free(target);
+		free_argv(argv);
 		return (0);
 	}
-	node->type = type;
-	node->target = target;
-	node->next = NULL;
-	if (!cmd->redirs)
-		cmd->redirs = node;
-	else
-	{
-		cur = cmd->redirs;
-		while (cur->next)
-			cur = cur->next;
-		cur->next = node;
-	}
+	(*i)++;
 	return (1);
 }
 
 static int	fill_argv_and_redirs(t_cmd *cmd, t_token *tok, t_err *err)
 {
-	char	**argv;
-	int		i;
+	int	i;
 
-	argv = malloc(sizeof(char *) * (cmd->argc + 1));
-	if (!argv)
+	cmd->argv = ft_calloc(cmd->argc + 1, sizeof(char *));
+	if (!cmd->argv)
 	{
 		*err = ERR_MALLOC;
 		return (0);
@@ -85,47 +47,24 @@ static int	fill_argv_and_redirs(t_cmd *cmd, t_token *tok, t_err *err)
 	{
 		if (tok->type == TOK_WORD)
 		{
-			argv[i] = ft_substr(tok->value, 0, ft_strlen(tok->value));
-			if (!argv[i])
-			{
-				*err = ERR_MALLOC;
-				free_argv(argv, i);
+			if (!add_word_arg(cmd->argv, &i, tok, err))
 				return (0);
-			}
-			i++;
 		}
-		else if (tok->type == TOK_REDIR_IN || tok->type == TOK_REDIR_OUT
-			|| tok->type == TOK_APPEND || tok->type == TOK_HEREDOC)
+		else if (is_redir_type(tok->type))
 		{
-			if (!tok->next || tok->next->type != TOK_WORD)
-			{
-				*err = ERR_MALLOC;
-				free_argv(argv, i);
-				return (0);
-			}
-			if (!add_redir(cmd, tok->type,
-					ft_substr(tok->next->value, 0,
-						ft_strlen(tok->next->value)), err))
-			{
-				free_argv(argv, i);
-				return (0);
-			}
+			if (!add_redir_from_token(cmd, tok, err))
+				return (free_argv(cmd->argv), cmd->argv = NULL, 0);
 			tok = tok->next;
 		}
 		tok = tok->next;
 	}
-	argv[i] = NULL;
-	cmd->argv = argv;
 	return (1);
 }
 
-t_cmd	*parse_simple_cmd(t_token *tokens, t_err *err)
+static t_cmd	*cmd_new(t_token *tokens, t_err *err)
 {
 	t_cmd	*cmd;
 
-	if (!tokens)
-		return (NULL);
-	*err = ERR_NONE;
 	cmd = malloc(sizeof(t_cmd));
 	if (!cmd)
 	{
@@ -135,8 +74,19 @@ t_cmd	*parse_simple_cmd(t_token *tokens, t_err *err)
 	cmd->argv = NULL;
 	cmd->argc = count_args(tokens);
 	cmd->redirs = NULL;
-	if (cmd->argc == 0)
-		return (cmd);
+	return (cmd);
+}
+
+t_cmd	*parse_simple_cmd(t_token *tokens, t_err *err)
+{
+	t_cmd	*cmd;
+
+	if (!tokens)
+		return (NULL);
+	*err = ERR_NONE;
+	cmd = cmd_new(tokens, err);
+	if (!cmd)
+		return (NULL);
 	if (!fill_argv_and_redirs(cmd, tokens, err))
 	{
 		free_redirs(cmd->redirs);

--- a/src/parsing/cmd_free.c
+++ b/src/parsing/cmd_free.c
@@ -1,18 +1,40 @@
 #include "minishell.h"
 
-void	free_cmd(t_cmd *cmd)
+void	free_argv(char **argv)
 {
 	int	i;
 
-	if (!cmd)
+	if (!argv)
 		return ;
 	i = 0;
-	while (cmd->argv && i < cmd->argc)
+	while (argv[i])
 	{
-		free(cmd->argv[i]);
+		free(argv[i]);
 		i++;
 	}
-	free(cmd->argv);
+	free(argv);
+}
+
+void	free_redirs(t_redir *list)
+{
+	t_redir	*next;
+
+	while (list)
+	{
+		next = list->next;
+		if (list->fd != -1)
+			close(list->fd);
+		free(list->target);
+		free(list);
+		list = next;
+	}
+}
+
+void	free_cmd(t_cmd *cmd)
+{
+	if (!cmd)
+		return ;
+	free_argv(cmd->argv);
 	free_redirs(cmd->redirs);
 	free(cmd);
 }

--- a/src/parsing/cmd_redir.c
+++ b/src/parsing/cmd_redir.c
@@ -1,0 +1,63 @@
+#include "minishell.h"
+
+int	is_redir_type(t_toktype type)
+{
+	return (type == TOK_REDIR_IN || type == TOK_REDIR_OUT
+		|| type == TOK_APPEND || type == TOK_HEREDOC);
+}
+
+static t_redir	*redir_new(t_toktype type, char *target, t_err *err)
+{
+	t_redir	*node;
+
+	node = malloc(sizeof(t_redir));
+	if (!node)
+	{
+		*err = ERR_MALLOC;
+		free(target);
+		return (NULL);
+	}
+	node->type = type;
+	node->target = target;
+	node->fd = -1;
+	node->next = NULL;
+	return (node);
+}
+
+static void	redir_add_back(t_redir **list, t_redir *node)
+{
+	t_redir	*cur;
+
+	if (!*list)
+	{
+		*list = node;
+		return ;
+	}
+	cur = *list;
+	while (cur->next)
+		cur = cur->next;
+	cur->next = node;
+}
+
+int	add_redir_from_token(t_cmd *cmd, t_token *tok, t_err *err)
+{
+	char	*target;
+	t_redir	*node;
+
+	if (!tok->next || tok->next->type != TOK_WORD)
+	{
+		*err = ERR_SYNTAX;
+		return (0);
+	}
+	target = ft_substr(tok->next->value, 0, ft_strlen(tok->next->value));
+	if (!target)
+	{
+		*err = ERR_MALLOC;
+		return (0);
+	}
+	node = redir_new(tok->type, target, err);
+	if (!node)
+		return (0);
+	redir_add_back(&cmd->redirs, node);
+	return (1);
+}

--- a/src/shell/main_loop.c
+++ b/src/shell/main_loop.c
@@ -21,6 +21,7 @@ static int	init_shell(t_shell *shell, char **envp)
 		return (0);
 	}
 	shell->last_status = 0;
+	shell->should_exit = 0;
 	setup_interactive_signals();
 	return (1);
 }
@@ -51,6 +52,8 @@ int	main_loop(char **envp)
 		add_history(line);
 		shell.last_status = run_once(line, &shell);
 		free(line);
+		if (shell.should_exit)
+			break ;
 	}
 	cleanup_shell(&shell);
 	return (shell.last_status);

--- a/src/shell/main_loop.c
+++ b/src/shell/main_loop.c
@@ -12,14 +12,32 @@ static int	is_blank_line(const char *line)
 	return (line[i] == '\0');
 }
 
+static int	init_shell(t_shell *shell, char **envp)
+{
+	shell->envp = env_dup(envp);
+	if (!shell->envp)
+	{
+		ft_putendl_fd("minishell: error: malloc failed", STDERR_FILENO);
+		return (0);
+	}
+	shell->last_status = 0;
+	setup_interactive_signals();
+	return (1);
+}
+
+static void	cleanup_shell(t_shell *shell)
+{
+	rl_clear_history();
+	free_argv(shell->envp);
+}
+
 int	main_loop(char **envp)
 {
 	t_shell	shell;
 	char	*line;
 
-	shell.envp = envp;
-	shell.last_status = 0;
-	setup_interactive_signals();
+	if (!init_shell(&shell, envp))
+		return (1);
 	while (1)
 	{
 		line = readline("minishell$ ");
@@ -34,6 +52,6 @@ int	main_loop(char **envp)
 		shell.last_status = run_once(line, &shell);
 		free(line);
 	}
-	rl_clear_history();
+	cleanup_shell(&shell);
 	return (shell.last_status);
 }

--- a/src/shell/run_once.c
+++ b/src/shell/run_once.c
@@ -1,9 +1,18 @@
 #include "minishell.h"
 
-
 static int	print_err(const char *msg)
 {
-	printf("%s\n", msg);
+	ft_putendl_fd((char *)msg, STDERR_FILENO);
+	return (1);
+}
+
+static int	handle_parse_error(t_token *list, t_err err)
+{
+	free_tokens(list);
+	if (err == ERR_MALLOC)
+		return (print_err("minishell: error: malloc failed"));
+	if (err == ERR_SYNTAX)
+		return (print_err("minishell: syntax error near unexpected token"));
 	return (1);
 }
 
@@ -19,11 +28,8 @@ int	run_once(const char *line, t_shell *shell)
 	if (!list && err == ERR_MALLOC)
 		return (print_err("minishell: error: malloc failed"));
 	cmd = parse_simple_cmd(list, &err);
-	if (!cmd && err == ERR_MALLOC)
-	{
-		free_tokens(list);
-		return (print_err("minishell: error: malloc failed"));
-	}
+	if (!cmd)
+		return (handle_parse_error(list, err));
 	shell->last_status = exec_simple_cmd(cmd, shell->envp);
 	free_cmd(cmd);
 	free_tokens(list);

--- a/src/shell/run_once.c
+++ b/src/shell/run_once.c
@@ -30,7 +30,7 @@ int	run_once(const char *line, t_shell *shell)
 	cmd = parse_simple_cmd(list, &err);
 	if (!cmd)
 		return (handle_parse_error(list, err));
-	shell->last_status = exec_simple_cmd(cmd, shell->envp);
+	shell->last_status = exec_simple_cmd(cmd, shell);
 	free_cmd(cmd);
 	free_tokens(list);
 	return (shell->last_status);

--- a/src/signals/signals.c
+++ b/src/signals/signals.c
@@ -3,16 +3,23 @@
 
 volatile sig_atomic_t	g_signal;
 
-static void	signal_handler(int sig)
+static void	interactive_handler(int sig)
 {
 	g_signal = sig;
 	if (sig == SIGINT)
 	{
-		write(1, "\n", 1);
+		write(STDOUT_FILENO, "\n", 1);
 		rl_on_new_line();
 		rl_replace_line("", 0);
 		rl_redisplay();
 	}
+}
+
+static void	heredoc_handler(int sig)
+{
+	g_signal = sig;
+	if (sig == SIGINT)
+		write(STDOUT_FILENO, "\n", 1);
 }
 
 void	setup_interactive_signals(void)
@@ -20,7 +27,20 @@ void	setup_interactive_signals(void)
 	struct sigaction	sa;
 
 	g_signal = 0;
-	sa.sa_handler = signal_handler;
+	sa.sa_handler = interactive_handler;
+	sigemptyset(&sa.sa_mask);
+	sa.sa_flags = 0;
+	sigaction(SIGINT, &sa, NULL);
+	sa.sa_handler = SIG_IGN;
+	sigaction(SIGQUIT, &sa, NULL);
+}
+
+void	setup_heredoc_signals(void)
+{
+	struct sigaction	sa;
+
+	g_signal = 0;
+	sa.sa_handler = heredoc_handler;
 	sigemptyset(&sa.sa_mask);
 	sa.sa_flags = 0;
 	sigaction(SIGINT, &sa, NULL);

--- a/src/signals/signals_exec.c
+++ b/src/signals/signals_exec.c
@@ -1,0 +1,23 @@
+#include "minishell.h"
+
+void	setup_wait_signals(void)
+{
+	struct sigaction	sa;
+
+	sa.sa_handler = SIG_IGN;
+	sigemptyset(&sa.sa_mask);
+	sa.sa_flags = 0;
+	sigaction(SIGINT, &sa, NULL);
+	sigaction(SIGQUIT, &sa, NULL);
+}
+
+void	setup_child_signals(void)
+{
+	struct sigaction	sa;
+
+	sa.sa_handler = SIG_DFL;
+	sigemptyset(&sa.sa_mask);
+	sa.sa_flags = 0;
+	sigaction(SIGINT, &sa, NULL);
+	sigaction(SIGQUIT, &sa, NULL);
+}


### PR DESCRIPTION
## Jira
- Ticket: MSH-14 Mandatory Builtins

Completed subtasks:
- MSH-53 Define builtin dispatch interface
- MSH-54 Implement pwd builtin
- MSH-55 Implement echo builtin with -n
- MSH-56 Implement env builtin
- MSH-57 Introduce mutable environment structure
- MSH-58 Implement export builtin without options
- MSH-59 Implement unset builtin without options
- MSH-60 Implement cd builtin with PWD/OLDPWD update
- MSH-61 Implement exit builtin
- MSH-62 Route parent-context builtins correctly
- MSH-63 Manual builtin test matrix

## What changed
- Implemented mandatory builtins: echo, pwd, env, export, unset, cd, and exit.
- Added builtin dispatch.
- Added mutable environment handling for export, unset, cd, env, expansion, and execution.
- Added parent-context builtin execution for builtins that modify shell state.
- Added support for builtins with redirections.
- Added exit handling through shell state and normal cleanup instead of calling exit() directly.
- Added builtin validation documentation:
  - docs/eval-prep/MSH-14-builtin-tests.md

Included base commit:
- 21cbb95 MSH-15 fix: prepare redirections before fork and stabilize heredoc

This earlier stabilization commit is included because the builtin implementation depends on the corrected redirection/heredoc execution flow.

It prepares redirections before forking, avoids unnecessary child execution on redirection errors, supports redirection-only commands, improves FD cleanup, and stabilizes heredoc behavior. This is relevant because builtins also need to behave correctly with redirections.

## Why
- The Minishell subject requires the mandatory builtins implemented in this PR.
- Some builtins must run in the parent process because they modify shell state:
  - cd changes the current working directory.
  - export modifies the shell environment.
  - unset modifies the shell environment.
  - exit changes shell control flow.
- A mutable environment is required so environment changes persist across commands.
- Builtin redirections need to work without permanently changing the shell standard input/output.
- The test matrix documents the manual validation performed for this ticket.

## How to test
- [ ] Build: make fclean && make
- [ ] No relink: make
- [ ] Run manual tests:
  - See docs/eval-prep/MSH-14-builtin-tests.md
- [ ] Valgrind / leaks:
  - See docs/eval-prep/MSH-14-builtin-tests.md
  - Expected relevant result:
    - definitely lost: 0 bytes
    - indirectly lost: 0 bytes
    - possibly lost: 0 bytes
    - ERROR SUMMARY: 0 errors
  - still reachable from readline/libreadline/libtinfo is expected.

## Scope & Subsystem
- Scope: Mandatory
- Subsystem: Builtins / Execution / Redirections / Expansion / Testing / Docs

## Checklist
- [x] Subject scope respected (no accidental bonus/extra features)
- [x] Norminette checked on touched files (if applicable)
- [x] No new leaks in tested paths (Valgrind where applicable)
- [x] No FD leaks in tested paths (pipes/redirs)
- [x] Exit status behavior ($?) verified where relevant
- [x] Signal behavior verified where relevant