### PR TITLE
docs(architecture): document current architecture and runtime flow

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,31 +1,172 @@
 # Architecture
 
-This directory contains documentation describing the current architecture of
-the repository.
+This directory contains the maintained architecture documentation for
+Minishell.
 
-Its purpose is to explain how the implemented system is structured and how its
-major components interact.
+The documents describe the current implementation as verified against the
+source tree. They are intended to help a developer understand the system at
+different levels without requiring a line-by-line reading of the code.
 
-## Scope
+## Documentation Map
 
-Architecture documentation may cover:
+| Document | Question it answers |
+| --- | --- |
+| [`system-overview.md`](system-overview.md) | What are the main subsystems, data structures and architectural boundaries? |
+| [`runtime-flow.md`](runtime-flow.md) | What happens to one input line from prompt to final exit status? |
+| [`process-and-signals.md`](process-and-signals.md) | Which process executes each kind of work, and which signal policy applies? |
+| [`resource-ownership.md`](resource-ownership.md) | Who owns memory and file descriptors, when does ownership move, and where are resources released? |
 
-- system and component boundaries;
-- runtime and execution flows;
-- ownership and lifetime of resources;
-- interactions between subsystems;
-- important data structures;
+## Recommended Reading Order
+
+For a first pass through the implementation:
+
+1. [`system-overview.md`](system-overview.md)
+2. [`runtime-flow.md`](runtime-flow.md)
+3. [`process-and-signals.md`](process-and-signals.md)
+4. [`resource-ownership.md`](resource-ownership.md)
+
+The documents are intentionally independent enough to be consulted
+individually.
+
+For example:
+
+- use the system overview when navigating the source tree;
+- use the runtime flow when tracing a command;
+- use the process and signal model when debugging process behaviour;
+- use the ownership model when reasoning about memory or file-descriptor
+  lifetime.
+
+## Source of Truth
+
+Architecture documentation in this directory describes the maintained
+implementation.
+
+When resolving discrepancies, use the following precedence:
+
+1. current source code;
+2. maintained architecture documentation in this directory;
+3. the repository-level README for public overview;
+4. historical development material.
+
+The source code remains authoritative for implemented behaviour.
+
+Architecture documentation explains that behaviour at subsystem and runtime
+level.
+
+## Current Architecture
+
+The implemented command lifecycle is:
+
+```text
+interactive input
+        |
+        v
+session
+        |
+        v
+scan + quote-aware expansion
+        |
+        v
+token list
+        |
+        v
+grammar
+        |
+        v
+linked command chain
+        |
+        v
+simple or pipeline execution
+        |
+        v
+exit status
+        |
+        v
+persistent shell state
+```
+
+The major maintained source domains are:
+
+```text
+src/
+├── session/
+├── scan/
+├── expand/
+├── grammar/
+├── exec/
+├── builtins/
+├── state/
+├── signals/
+└── support/
+```
+
+The architecture deliberately follows the final implementation rather than
+earlier design intentions.
+
+## Documentation Boundaries
+
+The documents in this directory cover:
+
+- subsystem responsibilities;
+- major runtime flows;
+- core data structures;
+- process boundaries;
+- signal contexts;
+- persistent and transient state;
+- memory ownership;
+- file-descriptor ownership;
 - architectural constraints.
 
-Documentation in this directory must describe the current implementation.
+They do not attempt to:
 
-Earlier designs, abandoned approaches and development-era architecture notes
-belong under [`../history/`](../history/).
+- document every function;
+- duplicate implementation details already clear from source;
+- serve as API reference documentation;
+- record the rationale for every engineering decision;
+- rewrite historical project material.
 
-## Current State
+Engineering rationale belongs in
+[`../decisions/`](../decisions/).
 
-Detailed architecture documentation will be established through the dedicated
-architecture modernization workstream.
+Detailed verification belongs in
+[`../testing/`](../testing/).
 
-Until that work is completed, the repository README provides the primary
-high-level description of the implemented system.
+## Historical Architecture
+
+Earlier design and development-stage architecture documents are preserved under:
+
+[`../history/design/`](../history/design/)
+
+They provide useful provenance but are not automatically authoritative for the
+final implementation.
+
+Notable differences between historical design material and the maintained
+implementation include:
+
+- variable expansion occurs during scanning while quote context is available;
+- pipelines are represented as linked `t_cmd` nodes rather than a separate
+  pipeline AST;
+- mutable environment state is stored directly as an owned `char **` in
+  `t_shell`;
+- pipeline construction uses rolling descriptor state;
+- source-module boundaries evolved during implementation.
+
+Historical documents should remain unchanged unless a separate historical
+correction is explicitly required.
+
+## Maintenance Rules
+
+Architecture documentation should remain:
+
+- aligned with implemented behaviour;
+- explicit about current limitations;
+- organized by architectural concern rather than source-file chronology;
+- linked to related maintained documentation;
+- independent from historical design material;
+- concise enough that each document has a clear purpose.
+
+When implementation changes invalidate an architectural claim, update the
+relevant maintained document in the same change whenever practical.
+
+New architecture documents should be added only when they introduce a distinct
+and durable concern that cannot be expressed clearly in the existing set.

--- a/docs/architecture/process-and-signals.md
+++ b/docs/architecture/process-and-signals.md
@@ -1,0 +1,605 @@
+# Process and Signal Model
+
+This document describes the process topology and context-dependent signal
+behaviour of the maintained Minishell implementation.
+
+For the overall system structure, see
+[`system-overview.md`](system-overview.md).
+
+For the complete command lifecycle, see
+[`runtime-flow.md`](runtime-flow.md).
+
+## Overview
+
+Minishell maintains one persistent interactive parent process and creates child
+processes only when the execution context requires them.
+
+The main runtime contexts are:
+
+```text
+interactive parent shell
+        |
+        +--> standalone builtin
+        |       executes in parent
+        |
+        +--> standalone external command
+        |       forks one execution child
+        |
+        +--> pipeline
+        |       forks one child per command stage
+        |
+        `--> heredoc preparation
+                forks one temporary heredoc child
+```
+
+Signal handling changes according to these contexts.
+
+## Process Roles
+
+### Interactive parent shell
+
+The original Minishell process owns the persistent session state.
+
+It is responsible for:
+
+- the readline prompt loop;
+- the mutable shell environment;
+- the previous exit status;
+- the session exit flag;
+- parsing and command construction;
+- creating execution children;
+- waiting for foreground work;
+- returning to the prompt after execution.
+
+This process survives across command lines until the session ends.
+
+### Standalone builtin execution
+
+A standalone builtin executes directly in the interactive parent process.
+
+The execution wrapper:
+
+1. saves parent `stdin` and `stdout`;
+2. applies command redirections;
+3. executes the builtin;
+4. restores the original standard descriptors.
+
+Running standalone builtins in the parent allows mutations of persistent shell
+state to survive the command.
+
+This is important for:
+
+- `cd`;
+- `export`;
+- `unset`;
+- `exit`.
+
+The same parent execution path is also used for non-stateful standalone
+builtins such as `echo`, `pwd` and `env`.
+
+### Standalone external command
+
+A standalone external command causes the parent to call `fork()`.
+
+The resulting topology is:
+
+```text
+Minishell parent
+      |
+      +-- fork
+           |
+           +--> parent
+           |      waits
+           |
+           `--> child
+                  applies redirections
+                  resolves command
+                  execve()
+```
+
+The child installs normal child signal behaviour before entering the common
+execution path.
+
+If `execve()` succeeds, the child process image is replaced by the target
+program.
+
+### Pipeline execution
+
+Each pipeline stage executes in its own child process.
+
+Conceptually:
+
+```text
+Minishell parent
+      |
+      +--> fork stage 1
+      |
+      +--> fork stage 2
+      |
+      +--> fork stage 3
+      |
+      `--> wait for all stages
+```
+
+Each child:
+
+1. installs child signal behaviour;
+2. connects its pipeline input and output;
+3. closes inherited pipeline descriptors;
+4. applies command-specific redirections;
+5. executes a builtin or external command.
+
+The parent remains responsible for advancing the rolling pipeline descriptor
+state and eventually collecting every pipeline child.
+
+### Pipeline builtins
+
+A builtin used as a pipeline stage executes in a pipeline child.
+
+For example:
+
+```text
+cd /tmp | cat
+```
+
+runs `cd` inside a child process.
+
+Changes to working directory, environment or `should_exit` therefore affect
+only that child's inherited process state.
+
+They do not modify the persistent parent shell.
+
+### Heredoc child
+
+Heredoc input is collected by a dedicated temporary child process before the
+command that consumes the heredoc is launched.
+
+The topology is:
+
+```text
+Minishell parent
+      |
+      +-- pipe
+      |
+      +-- fork
+           |
+           +--> heredoc child
+           |      readline("> ")
+           |      writes body to pipe
+           |      exits
+           |
+           `--> parent
+                  waits
+                  retains pipe read end
+```
+
+The resulting readable descriptor is stored for later redirection application.
+
+For pipelines, all heredocs are prepared before pipeline command children are
+launched.
+
+## Forked State
+
+A child created by `fork()` receives a process-local copy of the parent's
+address space and open descriptor table.
+
+This includes references to:
+
+- `t_shell`;
+- the token list;
+- the command chain;
+- the shell environment;
+- open file descriptors available at the fork point.
+
+Changes made by a child to ordinary process memory do not update the parent's
+copy.
+
+This is why stateful builtins must execute in the parent when their effects are
+expected to persist.
+
+## Child Cleanup
+
+Execution children use `exe_child_exit()` when they terminate through Minishell
+code.
+
+Before calling `exit()`, it releases the child's process-local copies of:
+
+- the token list;
+- the command chain;
+- the shell environment.
+
+This cleanup does not release or modify the corresponding objects in the
+parent process.
+
+After a successful `execve()`, the process image is replaced and this Minishell
+cleanup path is no longer used.
+
+## Signal Contexts
+
+Minishell does not use one signal configuration for the entire program.
+
+Instead, signal behaviour is installed according to the current runtime
+context.
+
+The maintained implementation defines four policies:
+
+| Context | `SIGINT` | `SIGQUIT` |
+| --- | --- | --- |
+| Interactive parent | custom handler | ignored |
+| Waiting parent | ignored | ignored |
+| Execution child | default | default |
+| Heredoc child | custom handler | ignored |
+
+These policies are installed through:
+
+- `sig_set_interactive()`;
+- `sig_set_waiting()`;
+- `sig_set_child()`;
+- `sig_set_heredoc()`.
+
+## Interactive Signal Policy
+
+The interactive parent installs `sig_set_interactive()` while accepting input.
+
+Readline's own signal catching is disabled:
+
+```text
+rl_catch_signals = 0
+```
+
+so Minishell controls the relevant signal behaviour.
+
+### Interactive `SIGINT`
+
+The custom interactive handler:
+
+1. records the signal in `g_signal`;
+2. writes `^C` and a newline;
+3. tells readline to begin a new line;
+4. replaces the current input buffer with an empty line;
+5. redisplays the prompt.
+
+Conceptually:
+
+```text
+Ctrl-C
+  |
+  v
+interactive_handler()
+  |
+  +--> g_signal = SIGINT
+  +--> clear current readline input
+  `--> redisplay prompt
+```
+
+After `readline()` returns control to the session loop,
+`ses_handle_signal()` observes the pending value.
+
+It then sets:
+
+```text
+shell.last_status = 130
+```
+
+and clears `g_signal`.
+
+This makes the interrupted interactive input visible through the next `$?`
+expansion.
+
+### Interactive `SIGQUIT`
+
+`SIGQUIT` is ignored while Minishell is at the interactive prompt.
+
+## Waiting Parent Policy
+
+When the parent is waiting for foreground child processes,
+`sig_set_waiting()` is installed.
+
+Both relevant signals are ignored by the parent:
+
+```text
+SIGINT  -> SIG_IGN
+SIGQUIT -> SIG_IGN
+```
+
+This policy is used while waiting for:
+
+- a standalone external command;
+- pipeline children;
+- a heredoc child.
+
+The foreground child processes therefore receive the execution-relevant signal
+behaviour without the interactive shell processing the same signal through its
+prompt handler.
+
+After normal foreground execution waits complete, the interactive policy is
+restored before Minishell returns to the prompt.
+
+## Execution Child Policy
+
+Execution children call `sig_set_child()`.
+
+This restores default behaviour for:
+
+```text
+SIGINT  -> SIG_DFL
+SIGQUIT -> SIG_DFL
+```
+
+The policy applies to:
+
+- standalone external-command children;
+- pipeline command children;
+- builtins executing as pipeline stages.
+
+An external program launched through `execve()` therefore inherits normal
+default behaviour for these signals rather than the interactive shell's custom
+handlers.
+
+## Simple Child Wait
+
+For one standalone external child, the parent uses `exe_wait_child()`.
+
+The sequence is:
+
+```text
+install waiting policy
+        |
+        v
+waitpid(child)
+        |
+        v
+restore interactive policy
+        |
+        v
+convert wait status
+```
+
+If the child exits normally, its exit code becomes the command status.
+
+If it is terminated by signal `N`, the shell status becomes:
+
+```text
+128 + N
+```
+
+For the relevant interactive signals, the wait path also emits the
+corresponding user-visible signal message.
+
+## Pipeline Wait
+
+Pipeline execution waits for all pipeline child processes.
+
+The parent tracks two different pieces of information:
+
+1. the wait status associated with the PID of the final pipeline stage;
+2. the first observed `SIGINT` or `SIGQUIT` termination used for the
+   user-visible signal message.
+
+The final pipeline status is based on the final stage:
+
+```text
+all children reaped
+       |
+       +--> signal message information
+       |
+       `--> status belonging to last_pid
+                         |
+                         v
+                 pipeline exit status
+```
+
+This preserves the shell convention that a pipeline's result is determined by
+its final command while still collecting every child.
+
+## Signal-Derived Status
+
+When a waited process terminates because of a signal, Minishell converts the
+result to:
+
+```text
+128 + signal_number
+```
+
+Therefore:
+
+```text
+SIGINT  -> 130
+SIGQUIT -> 131
+```
+
+for processes terminated by those conventional signal numbers.
+
+## Heredoc Signal Policy
+
+The heredoc reader uses a dedicated signal policy installed by
+`sig_set_heredoc()`.
+
+### Heredoc `SIGINT`
+
+The custom heredoc handler:
+
+1. stores `SIGINT` in `g_signal`;
+2. writes `^C`;
+3. closes the heredoc child's `STDIN_FILENO`.
+
+Closing standard input interrupts the `readline("> ")` input path.
+
+The heredoc read loop then detects the interrupted state and returns failure.
+
+The heredoc child converts that interruption into status `130` before exiting.
+
+### Heredoc `SIGQUIT`
+
+`SIGQUIT` is ignored in the heredoc child.
+
+## Heredoc Parent Wait
+
+The parent side of heredoc setup:
+
+1. closes the pipe write end;
+2. installs the waiting signal policy;
+3. waits for the heredoc child;
+4. converts the heredoc child's status;
+5. rejects the prepared heredoc if collection failed;
+6. otherwise retains the pipe read end.
+
+The surrounding redirection-preparation path restores the interactive signal
+policy after heredoc preparation completes.
+
+## Terminal State Around Heredocs
+
+Before the heredoc child is created, Minishell attempts to save the current
+terminal attributes with `tcgetattr()`.
+
+After the heredoc child finishes, the parent restores those attributes with
+`tcsetattr()` when a terminal state was successfully captured.
+
+This provides an additional boundary around readline and signal-driven heredoc
+interaction.
+
+## `g_signal`
+
+The implementation exposes:
+
+```c
+volatile sig_atomic_t g_signal;
+```
+
+as the small shared signal-state indicator used by the current process.
+
+Its meaning depends on process context.
+
+In the interactive parent it allows the session loop to observe an interrupt
+after the handler has updated readline state.
+
+In the heredoc child it allows the heredoc read loop to distinguish an
+interrupt from ordinary end-of-file.
+
+Because processes created by `fork()` have separate address spaces, each
+process operates on its own process-local copy after the fork.
+
+## `exit` and Process Context
+
+The `exit` builtin illustrates the importance of process context.
+
+When executed as a standalone builtin:
+
+```text
+parent shell
+    |
+    v
+blt_exit()
+    |
+    +--> shell.should_exit = 1
+    |
+    v
+session loop observes flag
+    |
+    v
+normal cleanup + session exit
+```
+
+When executed inside a pipeline:
+
+```text
+pipeline child
+    |
+    v
+blt_exit()
+    |
+    +--> child-local should_exit
+    |
+    v
+exe_child_exit()
+```
+
+The persistent parent shell continues running.
+
+## Process and Signal State Transitions
+
+A typical standalone external command follows:
+
+```text
+INTERACTIVE PARENT
+        |
+        | fork
+        v
++-----------------------+
+|                       |
+| parent                | child
+|                       |
+| waiting signals       | default signals
+|                       |
+| waitpid()             | execve()
+|                       |
++-----------+-----------+
+            |
+            v
+    restore interactive
+            |
+            v
+        next prompt
+```
+
+A pipeline follows the same general parent/child separation but creates one
+execution child per command stage.
+
+A heredoc introduces a temporary heredoc-specific signal context before command
+execution begins.
+
+## Context Summary
+
+```text
+PROMPT
+  parent
+  SIGINT custom
+  SIGQUIT ignored
+      |
+      v
+FOREGROUND EXECUTION
+  parent: signals ignored
+  children: signals default
+      |
+      v
+WAIT COMPLETE
+  parent restores interactive signals
+      |
+      v
+PROMPT
+```
+
+For heredoc preparation:
+
+```text
+HEREDOC SETUP
+  parent prepares pipe
+      |
+      +--> parent: waiting signals
+      |
+      `--> heredoc child:
+             SIGINT custom
+             SIGQUIT ignored
+      |
+      v
+HEREDOC COMPLETE
+  restore terminal
+  restore interactive policy
+```
+
+## Architectural Consequences
+
+The process model creates several important behavioural boundaries:
+
+- persistent shell state belongs to the interactive parent;
+- child state changes disappear when the child exits;
+- standalone builtins can mutate persistent state;
+- pipeline builtins cannot mutate the parent shell;
+- execution children receive normal signal semantics;
+- the parent does not process prompt signals while waiting;
+- heredoc input uses a specialized interrupt path;
+- foreground process status is converted back into shell-visible status;
+- the final pipeline stage determines the pipeline result.
+
+These behaviours are consequences of the maintained process architecture rather
+than separate post-processing rules.

--- a/docs/architecture/resource-ownership.md
+++ b/docs/architecture/resource-ownership.md
@@ -1,0 +1,1118 @@
+# Resource Ownership
+
+This document describes ownership and lifetime boundaries for memory, file
+descriptors and process-local resources in the maintained Minishell
+implementation.
+
+The goal is to make resource transfer and cleanup responsibilities explicit.
+
+For the overall subsystem model, see
+[`system-overview.md`](system-overview.md).
+
+For execution ordering, see
+[`runtime-flow.md`](runtime-flow.md).
+
+For process boundaries and signal behaviour, see
+[`process-and-signals.md`](process-and-signals.md).
+
+## Ownership Model
+
+Minishell operates with several different resource lifetimes:
+
+```text
+session lifetime
+    |
+    +--> t_shell
+    `--> shell-owned environment
+
+input-line lifetime
+    |
+    +--> readline buffer
+    +--> token list
+    `--> command chain
+
+execution lifetime
+    |
+    +--> redirection descriptors
+    +--> pipeline descriptors
+    +--> heredoc descriptors
+    `--> temporary stdio backups
+
+process-local lifetime
+    |
+    `--> resources inherited through fork()
+```
+
+The implementation relies on clear transitions between these lifetimes rather
+than one global cleanup owner.
+
+## Session-Owned State
+
+The interactive session owns one `t_shell` structure for the duration of
+`ses_loop()`.
+
+```c
+typedef struct s_shell
+{
+    char    **envp;
+    int     last_status;
+    int     should_exit;
+}   t_shell;
+```
+
+The structure itself is stack-allocated inside the session loop.
+
+Its dynamically allocated environment is initialized once and released when the
+session ends.
+
+## Environment Ownership
+
+At startup, `sta_env_copy()` creates a deep copy of the `envp` received by
+`main()`.
+
+Conceptually:
+
+```text
+process envp
+    |
+    | duplicate array
+    | duplicate each entry
+    v
+shell.envp
+```
+
+From that point onward, the persistent shell owns its environment copy.
+
+The original `envp` supplied by the process is not mutated by Minishell.
+
+### Environment lookup
+
+`sta_env_value()` returns a pointer into an existing environment entry.
+
+It does not allocate a new string and does not transfer ownership.
+
+Conceptually:
+
+```text
+shell.envp[i]
+"HOME=/home/user"
+      |
+      +--> returned pointer
+           "/home/user"
+```
+
+Callers must not free that returned pointer.
+
+When expansion requires an owned result, `exp_env_value()` duplicates the
+value.
+
+### Replacing an environment entry
+
+When an existing entry is replaced, the state subsystem:
+
+```text
+old entry string
+      |
+      v
+free()
+      |
+      v
+new duplicated string
+      |
+      v
+same envp slot
+```
+
+The outer environment array remains owned by the shell.
+
+### Extending the environment
+
+When a new variable is added:
+
+```text
+old char ** array
+      |
+      | transfer existing char * entries
+      v
+new char ** array
+      |
+      +--> existing strings
+      +--> duplicated new entry
+      `--> NULL
+```
+
+The old pointer array is released after its entries have been transferred.
+
+The strings themselves are not duplicated during that array transfer.
+
+### Removing an environment entry
+
+When an entry is removed:
+
+```text
+old environment
+      |
+      +--> removed string -> free()
+      |
+      `--> retained strings
+              |
+              | transfer
+              v
+          new char ** array
+```
+
+The old pointer array is then released.
+
+This preserves ownership of retained strings while freeing the removed entry.
+
+## Readline Input Ownership
+
+Each call to `readline()` returns a dynamically allocated line buffer.
+
+The session loop owns that buffer.
+
+```text
+readline()
+    |
+    v
+char *line
+    |
+    +--> scanner reads it
+    |
+    +--> history may copy/use it
+    |
+    v
+free(line)
+```
+
+The line remains valid throughout `ses_execute_line()` and is released after
+that call returns.
+
+The scanner does not take ownership of the original line.
+
+## Token Ownership
+
+The scanner creates a linked list of `t_token` objects.
+
+```c
+typedef struct s_token
+{
+    t_toktype       type;
+    char            *value;
+    struct s_token  *next;
+}   t_token;
+```
+
+Each token node owns itself.
+
+A `TOK_WORD` token also owns its `value`.
+
+Operator tokens normally have a null value.
+
+### Word construction
+
+Word scanning creates temporary segment strings.
+
+Conceptually:
+
+```text
+source line
+    |
+    v
+segment allocation
+    |
+    v
+optional expansion
+    |
+    v
+append into assembled word
+    |
+    v
+TOK_WORD.value
+```
+
+Temporary segment allocations are released as the word is assembled.
+
+The final assembled word is transferred to the token created by
+`scn_emit_word()`.
+
+### Token cleanup
+
+`scn_token_clear()` owns destruction of a complete token list.
+
+For every node it releases:
+
+```text
+token.value
+    |
+    v
+token node
+```
+
+The list can therefore be destroyed independently of the command model created
+later by grammar.
+
+## Command Ownership
+
+The grammar subsystem builds a separate linked command representation.
+
+```c
+typedef struct s_cmd
+{
+    char            **argv;
+    int             argc;
+    t_redir         *redirs;
+    struct s_cmd    *next;
+}   t_cmd;
+```
+
+A command node owns:
+
+```text
+t_cmd
+├── argv array
+├── argv strings
+├── redirection list
+└── command node itself
+```
+
+Commands do not borrow argument strings directly from tokens.
+
+## Token-to-Command Copy Boundary
+
+Grammar duplicates strings when constructing commands.
+
+For a normal word:
+
+```text
+t_token.value
+      |
+      | ft_strdup()
+      v
+cmd->argv[i]
+```
+
+For a redirection target:
+
+```text
+t_token.value
+      |
+      | ft_strdup()
+      v
+t_redir.target
+```
+
+This creates two independent ownership domains:
+
+```text
+scanner ownership
+    t_token + token.value
+
+grammar ownership
+    t_cmd + argv + t_redir
+```
+
+The token list and command chain can therefore be released independently.
+
+## Redirection Ownership
+
+Each redirection node is represented by:
+
+```c
+typedef struct s_redir
+{
+    t_toktype       type;
+    char            *target;
+    int             fd;
+    struct s_redir  *next;
+}   t_redir;
+```
+
+A redirection owns:
+
+```text
+redirection node
+redirection target string
+optional prepared descriptor
+```
+
+The descriptor field starts at:
+
+```text
+fd = -1
+```
+
+meaning no prepared descriptor is currently owned.
+
+## Prepared Redirection Descriptor
+
+During execution preparation, a redirection may acquire an open descriptor.
+
+For example:
+
+```text
+open(target)
+    |
+    v
+fd
+    |
+    v
+r->fd
+```
+
+At that point, the `t_redir` node owns the descriptor until it is either:
+
+```text
+consumed during application
+replaced
+or closed during cleanup
+```
+
+### Replacement during preparation
+
+If a redirection already owns a prepared descriptor and a new descriptor is
+assigned:
+
+```text
+old r->fd
+    |
+    v
+close()
+    |
+    v
+new r->fd
+```
+
+This prevents the redirection node from retaining multiple prepared
+descriptors.
+
+## Redirection Descriptor Transfer
+
+`exe_redir_one()` transfers a prepared descriptor out of the redirection node.
+
+Conceptually:
+
+```text
+r->fd
+  |
+  | move
+  v
+local fd
+
+r->fd = -1
+```
+
+After this point the redirection node no longer owns that descriptor.
+
+The execution path becomes responsible for it.
+
+## Effective Input and Output Descriptors
+
+While redirections are applied, execution tracks at most one effective input
+descriptor and one effective output descriptor:
+
+```text
+in_fd
+out_fd
+```
+
+When another redirection of the same direction is encountered, the previous
+effective descriptor is closed.
+
+Example:
+
+```text
+< first < second
+
+open first
+    |
+    v
+in_fd = first
+
+open second
+    |
+    +--> close first
+    |
+    v
+in_fd = second
+```
+
+The same rule applies to output redirections.
+
+This preserves source-order side effects while making the latest successfully
+processed descriptor the effective endpoint.
+
+## Applying Standard Descriptors
+
+After all redirections have been processed, effective descriptors are applied
+through `dup2()`.
+
+Conceptually:
+
+```text
+effective input fd
+        |
+       dup2
+        |
+        v
+      STDIN
+        |
+        v
+close original input fd
+```
+
+and:
+
+```text
+effective output fd
+        |
+       dup2
+        |
+        v
+      STDOUT
+        |
+        v
+close original output fd
+```
+
+The duplicated standard descriptor remains open as part of the process
+descriptor table.
+
+The original source descriptor is closed after duplication.
+
+## Redirection Cleanup Fallback
+
+If a command is destroyed while a redirection still has:
+
+```text
+r->fd != -1
+```
+
+`grm_redir_clear()` closes that descriptor.
+
+This provides cleanup for prepared resources that were not transferred to the
+normal application path.
+
+It then releases the redirection target and node.
+
+## Simple Command Preparation
+
+For a simple command, all redirection types are prepared before the execution
+path is selected.
+
+```text
+exe_simple()
+    |
+    v
+exe_redir_prepare()
+    |
+    +--> input files
+    +--> output files
+    +--> append files
+    `--> heredocs
+```
+
+Prepared descriptors are stored temporarily in the corresponding `t_redir`
+nodes.
+
+They are later consumed by:
+
+```text
+redirection-only execution
+standalone builtin execution
+or child execution
+```
+
+### Prepared descriptors across `fork()`
+
+For an external simple command, redirection preparation occurs before the
+execution child is created.
+
+After `fork()`, parent and child have process-local descriptor-table entries
+referring to the prepared resources.
+
+The child may transfer its copy through redirection application:
+
+```text
+child t_redir.fd
+        |
+        v
+effective fd
+        |
+       dup2
+        |
+        v
+STDIN / STDOUT
+```
+
+This does not modify the parent's `t_redir.fd`, because the processes have
+separate memory and descriptor tables after the fork.
+
+The parent retains its own prepared descriptor until the per-line command model
+is destroyed, at which point `grm_redir_clear()` closes any descriptor still
+owned by the parent-side redirection node.
+
+## Pipeline Redirection Preparation
+
+Pipeline preparation treats heredocs differently from normal file
+redirections.
+
+Before pipeline command children are launched:
+
+```text
+all pipeline heredocs
+        |
+        v
+prepared in parent context
+```
+
+Their readable descriptors are stored in `t_redir.fd`.
+
+Normal file redirections are opened later by the individual pipeline children
+during redirection application.
+
+This avoids globally pre-opening every ordinary pipeline file redirection.
+
+## Parent Standard-Stream Backups
+
+Some operations must temporarily redirect the persistent parent shell.
+
+These include:
+
+```text
+standalone builtins
+redirection-only commands
+```
+
+Before modifying the parent's standard descriptors:
+
+```text
+STDIN  -> dup() -> stdin_save
+STDOUT -> dup() -> stdout_save
+```
+
+The saved descriptors are owned by the current parent-execution scope.
+
+After the operation:
+
+```text
+stdin_save
+    |
+   dup2
+    |
+    v
+STDIN
+
+stdout_save
+    |
+   dup2
+    |
+    v
+STDOUT
+```
+
+The backup descriptors are then closed.
+
+This prevents command redirections from leaking into later prompt iterations.
+
+## Pipeline Descriptor Ownership
+
+Pipeline construction uses:
+
+```c
+typedef struct s_pipe_state
+{
+    int     prev_fd;
+    int     pipefd[2];
+    pid_t   last_pid;
+}   t_pipe_state;
+```
+
+The parent uses this state to manage only the descriptors needed for the current
+and next pipeline stage.
+
+## `prev_fd`
+
+`prev_fd` represents the readable endpoint inherited from the previous pipeline
+stage.
+
+While the next child is being created, the parent owns this descriptor.
+
+After the child has inherited the descriptor:
+
+```text
+old prev_fd
+      |
+      v
+close in parent
+```
+
+The new pipe's read end then becomes the next `prev_fd`.
+
+## Current Pipe Pair
+
+When another stage follows, the parent creates:
+
+```text
+pipefd[0]  read end
+pipefd[1]  write end
+```
+
+Both descriptors initially belong to the current process descriptor table.
+
+After `fork()`, both parent and child have inherited copies.
+
+Ownership responsibilities then diverge by process.
+
+## Pipeline Child Descriptor Setup
+
+The child uses the previous read descriptor when input from an earlier stage is
+required:
+
+```text
+prev_fd
+   |
+  dup2
+   |
+   v
+STDIN
+```
+
+When another stage follows, it uses the current write descriptor:
+
+```text
+pipefd[1]
+    |
+   dup2
+    |
+    v
+STDOUT
+```
+
+After those duplicates are established, the child closes the original inherited
+pipeline descriptors.
+
+The standard descriptors remain as the active communication endpoints.
+
+## Pipeline Parent Descriptor Progression
+
+After each stage is forked, the parent:
+
+```text
+close previous prev_fd
+close current write end
+retain current read end
+```
+
+The retained read end becomes the input candidate for the next stage.
+
+For the last command there is no next pipe to retain.
+
+The result is a rolling descriptor lifecycle:
+
+```text
+pipe 1 read
+    |
+    v
+prev_fd
+    |
+    | next stage launched
+    v
+close
+        pipe 2 read
+             |
+             v
+          prev_fd
+             |
+             v
+           close
+```
+
+## Pipeline Failure Cleanup
+
+If pipe creation or forking fails, `pipeline_fail()` closes descriptors still
+tracked by `t_pipe_state`.
+
+If at least one child has already been launched, the implementation also waits
+through the existing pipeline wait path before returning failure.
+
+This prevents the parent from simply abandoning tracked pipeline resources.
+
+## Heredoc Pipe Ownership
+
+Each heredoc begins with a new pipe:
+
+```text
+pipefd[0] = read end
+pipefd[1] = write end
+```
+
+After `fork()`, parent and heredoc child each inherit their own descriptor-table
+entries referring to those pipe endpoints.
+
+## Heredoc Child
+
+The heredoc child does not consume the read end.
+
+It therefore closes:
+
+```text
+pipefd[0]
+```
+
+and writes collected lines through:
+
+```text
+pipefd[1]
+```
+
+When collection completes or is interrupted, it closes the write end before
+terminating.
+
+Closing the writer is necessary for the future reader to observe end-of-file
+after buffered heredoc data has been consumed.
+
+## Heredoc Parent
+
+The parent does not write the heredoc body.
+
+It closes:
+
+```text
+pipefd[1]
+```
+
+before waiting for the heredoc child.
+
+If heredoc collection succeeds, the parent retains:
+
+```text
+pipefd[0]
+```
+
+and transfers that readable descriptor into:
+
+```text
+t_redir.fd
+```
+
+Ownership therefore becomes:
+
+```text
+heredoc pipe read end
+        |
+        v
+t_redir.fd
+        |
+        v
+redirection application
+        |
+        v
+STDIN
+```
+
+If heredoc collection fails, the parent closes the read end instead.
+
+## Heredoc Descriptor Consumption
+
+When the heredoc redirection is eventually applied:
+
+```text
+r->fd
+   |
+   | transfer
+   v
+in_fd
+   |
+  dup2
+   |
+   v
+STDIN
+   |
+   v
+close original heredoc read fd
+```
+
+The command then reads heredoc content through its standard input.
+
+## Heredoc Terminal State
+
+Heredoc setup may also temporarily own a copy of terminal attributes:
+
+```text
+struct termios saved
+```
+
+This object is stack storage rather than heap memory.
+
+When `tcgetattr()` succeeds, the caller records that the saved state is valid.
+
+After the heredoc child finishes, the parent restores the terminal attributes
+with `tcsetattr()`.
+
+The lifetime is limited to one heredoc setup operation.
+
+## Child Process Memory
+
+`fork()` gives the child a process-local copy of the parent's memory state.
+
+Conceptually:
+
+```text
+parent
+├── shell
+├── environment
+├── tokens
+└── commands
+      |
+      | fork
+      v
+child-local copies
+├── shell
+├── environment
+├── tokens
+└── commands
+```
+
+The physical implementation may use copy-on-write internally, but ownership
+from Minishell's perspective becomes process-local after the fork.
+
+A child can therefore release its inherited Minishell resources without
+destroying the parent's corresponding objects.
+
+## `t_child_ctx`
+
+Execution passes a small context:
+
+```c
+typedef struct s_child_ctx
+{
+    t_cmd       *cmds;
+    t_token     *tokens;
+    t_shell     *shell;
+}   t_child_ctx;
+```
+
+The structure carries references used during execution and child cleanup.
+
+It does not create another ownership copy by itself.
+
+Its pointers refer to resources already owned by the surrounding process.
+
+## Child Exit Cleanup
+
+When a child exits through Minishell code, `exe_child_exit()` releases its
+process-local inherited resources:
+
+```text
+tokens
+    |
+    v
+scn_token_clear()
+
+commands
+    |
+    v
+grm_clear()
+
+shell.envp
+    |
+    v
+sup_free_array()
+
+process
+    |
+    v
+exit(status)
+```
+
+The `t_shell` structure itself is not heap-allocated and therefore is not freed.
+
+After `fork()`, this cleanup affects only the child's process-local memory.
+
+## Successful `execve()`
+
+A successful `execve()` replaces the current child process image.
+
+In that case Minishell does not return to `exe_child()` and does not execute
+`exe_child_exit()`.
+
+The operating system replaces the process memory image as part of `execve()`.
+
+Descriptors not intentionally closed before `execve()` remain subject to normal
+process descriptor semantics.
+
+The execution path therefore closes or redirects pipeline and command
+descriptors before attempting the external program.
+
+## Per-Line Parent Cleanup
+
+After execution returns to `ses_execute_line()`, the parent releases:
+
+```text
+command chain
+    |
+    v
+grm_clear()
+
+token list
+    |
+    v
+scn_token_clear()
+```
+
+The original readline buffer is then released by `ses_loop()`.
+
+The persistent environment is intentionally retained for the next prompt.
+
+## Session Cleanup
+
+When the interactive session ends:
+
+```text
+readline history
+    |
+    v
+rl_clear_history()
+
+shell environment
+    |
+    v
+sup_free_array(shell.envp)
+```
+
+The session then returns its final status.
+
+## Failure Boundaries
+
+Resource cleanup is distributed according to the layer that acquired the
+resource.
+
+Examples include:
+
+```text
+scanner allocation failure
+    -> scanner clears partial token list
+
+grammar construction failure
+    -> grammar clears partial command structures
+
+redirection application failure
+    -> execution closes effective redirection descriptors
+
+pipeline setup failure
+    -> pipeline closes tracked pipe descriptors
+
+heredoc failure
+    -> heredoc parent closes retained pipe endpoint
+
+child execution failure
+    -> child-local cleanup before exit
+```
+
+This keeps cleanup responsibilities close to the operations that understand the
+resource state.
+
+## Ownership Summary
+
+| Resource | Primary owner | Typical release point |
+| --- | --- | --- |
+| `t_shell` structure | session stack | return from `ses_loop()` |
+| `shell.envp` | interactive session | `ses_cleanup()` |
+| readline input buffer | prompt iteration | after `ses_execute_line()` |
+| `t_token` list | per-line scanner model | `scn_token_clear()` |
+| token values | owning token | `scn_token_clear()` |
+| `t_cmd` chain | per-line grammar model | `grm_clear()` |
+| command `argv` | owning command | `grm_clear()` |
+| redirection target | owning `t_redir` | `grm_redir_clear()` |
+| prepared `t_redir.fd` | redirection node | transfer or redirection cleanup |
+| effective `in_fd` / `out_fd` | redirection application | after `dup2()` or failure |
+| parent stdio backups | parent execution scope | after restore |
+| pipeline `prev_fd` | pipeline parent | after next stage is launched |
+| current pipeline pair | parent and child after `fork()` | context-specific close |
+| heredoc write end | heredoc child | heredoc completion |
+| heredoc read end | parent, then `t_redir` | redirection application |
+| child-local inherited models | execution child | `exe_child_exit()` |
+| saved heredoc terminal state | heredoc setup stack | end of setup |
+
+## Ownership Transfers
+
+The most important transfer paths can be summarized as:
+
+```text
+scanner word
+    |
+    v
+t_token.value
+```
+
+```text
+t_token.value
+    |
+    | duplicate
+    v
+cmd->argv / redir->target
+```
+
+```text
+open redirection fd
+    |
+    v
+t_redir.fd
+    |
+    | transfer
+    v
+effective in_fd/out_fd
+    |
+    | dup2
+    v
+STDIN/STDOUT
+```
+
+```text
+heredoc pipe read end
+    |
+    v
+t_redir.fd
+    |
+    v
+STDIN
+```
+
+```text
+pipeline read end
+    |
+    v
+parent prev_fd
+    |
+    | inherited through fork
+    v
+child
+    |
+    | dup2
+    v
+STDIN
+```
+
+These transitions are the main points where responsibility for cleanup changes.
+
+## Architectural Consequences
+
+The ownership model supports several important properties of the maintained
+implementation:
+
+- persistent session state is isolated from per-line parsing state;
+- token and command representations can be destroyed independently;
+- parent-process redirections are temporary and reversible;
+- prepared redirection descriptors have an explicit fallback cleanup owner;
+- pipeline descriptors are closed progressively instead of accumulated in one
+  long-lived descriptor array;
+- heredoc descriptors move through an explicit producer-to-redirection
+  lifecycle;
+- child processes can clean inherited Minishell state independently;
+- environment mutations remain under the persistent shell's ownership.
+
+This document describes ownership as implemented in the current source tree.
+
+It does not claim that every future extension should preserve the same resource
+model.

--- a/docs/architecture/runtime-flow.md
+++ b/docs/architecture/runtime-flow.md
@@ -1,0 +1,827 @@
+# Runtime Flow
+
+This document describes the end-to-end runtime flow of one Minishell input line.
+
+It focuses on the order in which the maintained implementation scans input,
+expands variables, constructs commands, prepares execution resources, launches
+processes and propagates the resulting status back into the persistent shell
+session.
+
+For the overall subsystem model, see [`system-overview.md`](system-overview.md).
+
+## End-to-End Command Lifecycle
+
+At the highest level, one interactive command follows this path:
+
+```text
+readline()
+    |
+    v
+ses_execute_line()
+    |
+    v
+scn_line()
+    |
+    +--> quote-aware variable expansion
+    |
+    v
+t_token list
+    |
+    v
+grm_pipeline()
+    |
+    v
+t_cmd chain
+    |
+    v
+execution dispatch
+    |
+    +--> exe_simple()
+    |
+    `--> exe_pipeline()
+              |
+              v
+        execution result
+              |
+              v
+      shell.last_status
+              |
+              v
+          next prompt
+```
+
+The persistent `t_shell` object survives this entire cycle and is reused for
+the next command line.
+
+## 1. Interactive Input
+
+The session loop is implemented by `ses_loop()`.
+
+For each prompt iteration it:
+
+1. reads a line with `readline("minishell$ ")`;
+2. processes any interactive `SIGINT` state;
+3. exits the loop on end-of-file;
+4. skips blank input;
+5. adds non-blank input to readline history;
+6. calls `ses_execute_line()`;
+7. stores the returned result in `shell.last_status`;
+8. checks whether a builtin requested session termination.
+
+The input buffer returned by `readline()` is owned by the session loop and is
+freed after the line has been processed.
+
+## 2. Line Execution Boundary
+
+`ses_execute_line()` coordinates the main phases for one input line:
+
+```text
+input line
+    |
+    v
+scan
+    |
+    v
+grammar
+    |
+    v
+dispatch
+    |
+    v
+cleanup
+```
+
+It is also the boundary that converts scanner and grammar failures into shell
+status values and user-visible errors.
+
+### Scanner failure
+
+The scanner may report:
+
+- `ERR_UNCLOSED_QUOTE`;
+- `ERR_MALLOC`.
+
+An empty result with `ERR_NONE` is treated as a successful no-op with status
+`0`.
+
+### Grammar failure
+
+Grammar failures may report:
+
+- `ERR_SYNTAX`;
+- `ERR_MALLOC`.
+
+When grammar construction fails, the token list is released before returning.
+
+### Successful execution
+
+When both scanning and grammar construction succeed:
+
+1. commands are dispatched for execution;
+2. the returned execution result becomes `shell.last_status`;
+3. the command chain is released;
+4. the token list is released;
+5. the resulting status is returned to the session loop.
+
+## 3. Scanning and Quote-Aware Expansion
+
+`scn_line()` walks the input line from left to right.
+
+It skips shell whitespace and distinguishes between:
+
+- words;
+- `|`;
+- `<`;
+- `>`;
+- `<<`;
+- `>>`.
+
+Operators are emitted directly as token nodes.
+
+Everything else is assembled through `scn_word()`.
+
+## 4. Word Construction
+
+A word may be built from multiple adjacent segments.
+
+For example, conceptually:
+
+```text
+abc"$USER"'xyz'
+```
+
+is processed as several segments that are joined into one resulting word.
+
+The scanner distinguishes three segment types.
+
+### Plain segments
+
+Plain unquoted text is extracted and passed through `exp_variables()`.
+
+### Single-quoted segments
+
+Single-quoted text is copied literally.
+
+Variable expansion is not performed.
+
+### Double-quoted segments
+
+Double-quoted text is extracted and passed through `exp_variables()`.
+
+The quote delimiters themselves are not retained in the resulting word.
+
+## 5. Variable Expansion
+
+Expansion happens during word scanning while quote context is still known.
+
+The maintained implementation supports:
+
+- environment variables such as `$HOME`;
+- the previous command status through `$?`;
+- literal `$` when no valid expansion target follows.
+
+This produces the effective string that is stored in the word token.
+
+The runtime order is therefore:
+
+```text
+source text
+    |
+    v
+segment classification
+    |
+    +--> single quote --> literal text
+    |
+    +--> plain --------> expansion
+    |
+    `--> double quote -> expansion
+             |
+             v
+        assembled word
+             |
+             v
+         TOK_WORD
+```
+
+Expansion is not a separate phase after grammar construction.
+
+## 6. Token Stream
+
+The scanner produces a linked list of `t_token` nodes.
+
+A command such as:
+
+```text
+cat < input.txt | grep foo >> output.txt
+```
+
+is represented conceptually as:
+
+```text
+WORD(cat)
+REDIR_IN
+WORD(input.txt)
+PIPE
+WORD(grep)
+WORD(foo)
+APPEND
+WORD(output.txt)
+```
+
+Word strings belong to the token nodes until the token list is destroyed.
+
+## 7. Grammar Construction
+
+`grm_pipeline()` validates the pipe structure and converts the token stream into
+a linked command chain.
+
+It rejects:
+
+- a leading pipe;
+- a trailing pipe;
+- consecutive pipes.
+
+The token stream is then split into command segments at each `TOK_PIPE`.
+
+Each segment becomes one `t_cmd`.
+
+## 8. Command Construction
+
+For each command segment, grammar separates command arguments from
+redirections.
+
+Word tokens that are normal command arguments are copied into `argv`.
+
+Redirection operators and their following word tokens are converted into
+`t_redir` nodes.
+
+Conceptually:
+
+```text
+WORD(cat)
+REDIR_IN
+WORD(input.txt)
+WORD(extra)
+```
+
+becomes:
+
+```text
+t_cmd
+├── argv
+│   ├── "cat"
+│   └── "extra"
+│
+└── redirs
+    └── TOK_REDIR_IN -> "input.txt"
+```
+
+Redirection targets are therefore not included in `argv`.
+
+## 9. Execution Dispatch
+
+After grammar construction, the session counts the command nodes.
+
+```text
+command count == 1
+        |
+        v
+    exe_simple()
+
+command count > 1
+        |
+        v
+   exe_pipeline()
+```
+
+This is the main execution fork in the architecture.
+
+## 10. Simple Command Flow
+
+`exe_simple()` first creates an execution context and prepares the command's
+redirections.
+
+The flow then branches:
+
+```text
+exe_simple()
+    |
+    v
+prepare redirections
+    |
+    +--> argc == 0
+    |       |
+    |       v
+    |   redirection-only execution
+    |
+    +--> builtin
+    |       |
+    |       v
+    |   execute in parent
+    |
+    `--> external command
+            |
+            v
+           fork
+            |
+            v
+        child execution
+```
+
+## 11. Redirection Preparation for Simple Commands
+
+For a simple command, `exe_redir_prepare()` visits every redirection before the
+final execution path is selected.
+
+It may:
+
+- open input files;
+- create or truncate output files;
+- open append targets;
+- collect heredoc input.
+
+The resulting descriptor is stored temporarily in the corresponding
+`t_redir.fd`.
+
+This means that redirection side effects and failures occur before choosing
+between parent builtin execution and child external execution.
+
+## 12. Redirection-Only Commands
+
+A command segment may contain redirections without an executable command.
+
+In that case:
+
+1. parent `stdin` and `stdout` are saved;
+2. the redirections are applied;
+3. no command body is executed;
+4. the original standard descriptors are restored.
+
+This allows redirection side effects to occur without permanently changing the
+interactive shell's standard streams.
+
+## 13. Standalone Builtins
+
+Standalone builtins execute inside the persistent shell process.
+
+The parent execution wrapper performs:
+
+```text
+save stdin/stdout
+      |
+      v
+apply redirections
+      |
+      v
+execute builtin
+      |
+      v
+restore stdin/stdout
+```
+
+Running the builtin in the parent allows changes to session state to survive.
+
+This matters for commands such as:
+
+- `cd`;
+- `export`;
+- `unset`;
+- `exit`.
+
+The same parent path is also used for non-stateful standalone builtins.
+
+## 14. External Simple Commands
+
+External simple commands are executed through `fork()`.
+
+The child:
+
+1. installs child signal behaviour;
+2. applies command redirections;
+3. chooses direct-path or `PATH` execution;
+4. calls `execve()`.
+
+The parent waits for that child and converts its wait status into the shell
+status.
+
+## 15. External Command Resolution
+
+Commands containing `/` are treated as explicit paths.
+
+They are passed directly to `execve()` after directory and execution-error
+handling.
+
+Commands without `/` are resolved through the shell-owned `PATH` value.
+
+The lookup process:
+
+1. reads `PATH`;
+2. splits it by `:`;
+3. builds candidate `directory/command` paths;
+4. selects the first executable candidate;
+5. passes it to `execve()`.
+
+The execution layer distinguishes command-not-found and
+found-but-not-executable outcomes through shell exit statuses.
+
+## 16. Pipeline Preparation
+
+A command chain containing multiple `t_cmd` nodes enters `exe_pipeline()`.
+
+Before any pipeline command child is launched, all heredocs belonging to all
+pipeline stages are collected.
+
+The order is:
+
+```text
+command chain
+      |
+      v
+prepare every heredoc
+      |
+      +--> failure or interrupt --> abort pipeline
+      |
+      v
+launch pipeline stages
+```
+
+Normal file redirections are not globally pre-opened for the pipeline.
+
+They are handled later in the corresponding execution child.
+
+## 17. Rolling Pipeline Construction
+
+The pipeline executor uses `t_pipe_state` rather than allocating an array of all
+pipeline descriptors.
+
+It keeps only:
+
+- the previous stage's readable descriptor;
+- the current pipe pair;
+- the PID of the most recently launched stage.
+
+For a three-stage pipeline:
+
+```text
+command A
+    |
+    +-- create pipe 1
+    +-- fork A
+    +-- retain read end of pipe 1
+              |
+              v
+command B
+    |
+    +-- use previous read end
+    +-- create pipe 2
+    +-- fork B
+    +-- close previous read end in parent
+    +-- retain read end of pipe 2
+              |
+              v
+command C
+    |
+    +-- use previous read end
+    +-- no next pipe required
+    `-- fork C
+```
+
+This keeps the parent pipeline state bounded while stages are launched
+incrementally.
+
+## 18. Pipeline Child Wiring
+
+Before executing the command body, each pipeline child connects the required
+pipeline endpoints.
+
+If a previous stage exists:
+
+```text
+previous pipe read end
+        |
+       dup2
+        |
+        v
+      STDIN
+```
+
+If another stage follows:
+
+```text
+current pipe write end
+        |
+       dup2
+        |
+        v
+      STDOUT
+```
+
+After duplicating the relevant descriptors, the child closes the inherited
+pipeline descriptors.
+
+It then enters the common `exe_child()` execution path.
+
+## 19. Redirections Override Pipeline Wiring
+
+Pipeline wiring happens before command-specific redirections are applied.
+
+The ordering is:
+
+```text
+pipeline stdin/stdout setup
+          |
+          v
+exe_child()
+          |
+          v
+command redirections
+          |
+          v
+builtin or execve
+```
+
+As a consequence, a command-level redirection may replace a descriptor
+previously connected to a pipeline.
+
+Conceptually:
+
+```text
+producer | consumer < file
+```
+
+connects the pipeline first, then the input redirection replaces the consumer's
+`STDIN` with `file`.
+
+Likewise:
+
+```text
+producer > file | consumer
+```
+
+connects the producer to the pipe first, then the output redirection replaces
+its `STDOUT` with `file`.
+
+## 20. Redirection Ordering
+
+Redirections are processed in their original source order.
+
+For repeated input or output redirections, the most recently processed
+descriptor becomes the effective one.
+
+Earlier redirections are still opened before being replaced.
+
+Therefore they may still:
+
+- create or truncate files;
+- fail;
+- produce other observable filesystem effects.
+
+The effective descriptor is then duplicated onto `STDIN` or `STDOUT`.
+
+## 21. Heredoc Flow
+
+A heredoc is collected through a dedicated process and pipe.
+
+The setup flow is:
+
+```text
+create pipe
+    |
+    v
+save terminal state
+    |
+    v
+fork
+    |
+    +-------------------------+
+    |                         |
+    v                         v
+heredoc child             parent
+    |                         |
+close read end            close write end
+    |                         |
+install heredoc signals   wait for child
+    |                         |
+readline("> ") loop       evaluate status
+    |                         |
+write body to pipe        retain read end
+    |                         |
+close write end           restore terminal
+    |                         |
+exit                       v
+                       prepared t_redir.fd
+```
+
+The command later consumes the read side of the heredoc pipe as an input
+redirection.
+
+## 22. Heredoc Body Semantics
+
+The current heredoc reader writes each collected line directly to the pipe.
+
+It does not call the variable-expansion subsystem.
+
+Therefore the maintained baseline does not expand `$VAR` or `$?` inside heredoc
+bodies.
+
+This is an implementation limitation and differs from complete Bash heredoc
+behaviour.
+
+## 23. Common Child Execution
+
+Simple external commands and pipeline stages converge on `exe_child()`.
+
+Inside the child:
+
+```text
+apply redirections
+      |
+      +--> no argv
+      |       |
+      |       v
+      |     exit 0
+      |
+      +--> builtin
+      |       |
+      |       v
+      |   execute builtin
+      |       |
+      |       v
+      |     exit
+      |
+      +--> direct path
+      |       |
+      |       v
+      |     execve
+      |
+      `--> PATH lookup
+              |
+              v
+            execve
+```
+
+If `execve()` succeeds, the Minishell child image is replaced by the external
+program.
+
+If execution fails, the child converts the failure into a shell status, cleans
+its inherited Minishell resources and exits.
+
+## 24. Child Cleanup
+
+Execution children inherit the parent's memory through `fork()`.
+
+Before an execution child exits through Minishell code, `exe_child_exit()`
+releases its process-local copies of:
+
+- the token list;
+- the command chain;
+- the shell environment.
+
+This cleanup affects only the child's address space.
+
+The persistent parent retains its own copies until its normal cleanup points.
+
+## 25. Waiting for a Simple Child
+
+For a standalone external command, the parent:
+
+1. installs the waiting signal policy;
+2. calls `waitpid()` for the child;
+3. restores the interactive signal policy;
+4. converts the wait result into a shell status.
+
+Normal child exit produces its exit code.
+
+Signal termination produces:
+
+```text
+128 + signal_number
+```
+
+## 26. Waiting for a Pipeline
+
+The pipeline parent waits until all child processes have been reaped.
+
+It separately tracks the PID of the final pipeline stage.
+
+The returned pipeline status is therefore based on the last stage, while all
+pipeline children are still collected.
+
+Conceptually:
+
+```text
+wait all pipeline children
+         |
+         +--> collect signal information
+         |
+         `--> identify last_pid status
+                       |
+                       v
+                pipeline status
+```
+
+## 27. Status Propagation
+
+The final execution result returns through the same boundary regardless of the
+execution path:
+
+```text
+execution result
+      |
+      v
+ses_execute_line()
+      |
+      v
+shell.last_status
+      |
+      v
+ses_loop()
+```
+
+That value then becomes observable through:
+
+- the next `$?` expansion;
+- the shell's eventual return value;
+- `exit` without an explicit numeric argument.
+
+## 28. Session Exit
+
+The `exit` builtin does not immediately bypass session cleanup when executed in
+the parent shell.
+
+Instead it sets:
+
+```text
+shell.should_exit = 1
+```
+
+and returns an exit status.
+
+After the line finishes:
+
+```text
+ses_execute_line()
+      |
+      v
+ses_loop()
+      |
+      +--> should_exit == 0 --> next prompt
+      |
+      `--> should_exit != 0
+                 |
+                 v
+              cleanup
+                 |
+                 v
+              return
+```
+
+When `exit` runs inside a pipeline child, the modified `should_exit` belongs
+only to that child process and does not terminate the parent shell session.
+
+## Runtime Summary
+
+The complete maintained runtime can be summarized as:
+
+```text
+persistent shell state
+        |
+        v
+interactive input
+        |
+        v
+scan + quote-aware expansion
+        |
+        v
+token representation
+        |
+        v
+grammar + command representation
+        |
+        v
+execution dispatch
+   +----+---------------------+
+   |                          |
+   v                          v
+simple                    pipeline
+   |                          |
+   +--> parent builtin        +--> prepare heredocs
+   +--> redir-only            +--> rolling pipe launch
+   `--> child command         `--> child commands
+            |                          |
+            +------------+-------------+
+                         |
+                         v
+                 wait / collect status
+                         |
+                         v
+                  shell.last_status
+                         |
+                         v
+                     next prompt
+```
+
+This flow describes the current maintained implementation.
+
+Earlier development-stage runtime descriptions remain preserved under
+[`../history/design/`](../history/design/) for historical context.

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -7,8 +7,8 @@ It focuses on system boundaries, subsystem responsibilities, the core runtime
 data model and the distinction between persistent shell state and
 per-command execution state.
 
-For the detailed command lifecycle, see `runtime-flow.md` once that document is
-available.
+For the detailed command lifecycle, see
+[`runtime-flow.md`](runtime-flow.md).
 
 ## Architectural Overview
 
@@ -101,7 +101,8 @@ flowchart TD
 The diagram shows logical dependencies rather than ownership of every
 individual allocation or file descriptor.
 
-Resource ownership is documented separately in `resource-ownership.md`.
+Resource ownership is documented separately in
+[`resource-ownership.md`](resource-ownership.md).
 
 ## Session Boundary
 
@@ -422,7 +423,7 @@ The implementation distinguishes policies for:
 - heredoc input.
 
 Detailed process and signal behaviour is documented in
-`process-and-signals.md`.
+[`process-and-signals.md`](process-and-signals.md).
 
 ## Architecture Constraints
 

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -1,0 +1,455 @@
+# System Overview
+
+This document describes the maintained architecture of Minishell as implemented
+in the current source tree.
+
+It focuses on system boundaries, subsystem responsibilities, the core runtime
+data model and the distinction between persistent shell state and
+per-command execution state.
+
+For the detailed command lifecycle, see `runtime-flow.md` once that document is
+available.
+
+## Architectural Overview
+
+Minishell is an interactive command interpreter organized as a set of small C
+subsystems around a persistent shell session.
+
+At a high level, input moves through the following stages:
+
+```text
+interactive input
+      |
+      v
+session management
+      |
+      v
+scan + quote-aware expansion
+      |
+      v
+token list
+      |
+      v
+grammar
+      |
+      v
+command chain
+      |
+      v
+execution
+      |
+      v
+exit status + persistent shell state
+```
+
+Variable expansion is performed while words are scanned, not as a separate
+post-parse phase.
+
+This allows the scanner to apply different expansion behaviour while quote
+context is still available.
+
+## System Boundaries
+
+The maintained implementation is divided into the following source domains:
+
+| Domain | Responsibility |
+| --- | --- |
+| `main.c` | Validates invocation and enters the shell session |
+| `session/` | Owns the interactive lifecycle and per-line command lifecycle |
+| `scan/` | Recognizes words and shell operators and constructs tokens |
+| `expand/` | Expands environment variables and the previous exit status |
+| `grammar/` | Converts tokens into executable command structures |
+| `exec/` | Executes commands, pipelines, redirections, heredocs and external programs |
+| `builtins/` | Identifies and executes supported shell builtins |
+| `state/` | Owns environment lookup and mutation operations |
+| `signals/` | Installs signal policies for different runtime contexts |
+| `support/` | Provides small shared utility functions |
+
+These domains describe the final source organization rather than the earlier
+design structure preserved under `docs/history/design/`.
+
+## High-Level Component Relationships
+
+```mermaid
+flowchart TD
+    MAIN["main.c"] --> SESSION["session/"]
+
+    SESSION --> SCAN["scan/"]
+    SCAN --> EXPAND["expand/"]
+    EXPAND --> STATE["state/"]
+
+    SCAN --> TOKENS["t_token list"]
+    TOKENS --> GRAMMAR["grammar/"]
+
+    GRAMMAR --> COMMANDS["t_cmd chain"]
+    COMMANDS --> EXEC["exec/"]
+
+    EXEC --> BUILTINS["builtins/"]
+    EXEC --> STATE
+    EXEC --> SIGNALS["signals/"]
+
+    BUILTINS --> STATE
+    SESSION --> SIGNALS
+
+    SHELL["t_shell"] --> SESSION
+    SHELL --> EXPAND
+    SHELL --> EXEC
+    SHELL --> BUILTINS
+    SHELL --> STATE
+```
+
+The diagram shows logical dependencies rather than ownership of every
+individual allocation or file descriptor.
+
+Resource ownership is documented separately in `resource-ownership.md`.
+
+## Session Boundary
+
+The persistent runtime state of the interactive shell is represented by
+`t_shell`:
+
+```c
+typedef struct s_shell
+{
+    char    **envp;
+    int     last_status;
+    int     should_exit;
+}   t_shell;
+```
+
+The session initializes this structure once when Minishell starts.
+
+Its lifetime spans multiple command lines.
+
+### `envp`
+
+`envp` is an owned mutable copy of the process environment received by
+`main()`.
+
+The state subsystem provides operations to:
+
+- copy the initial environment;
+- look up variables;
+- add or replace entries;
+- remove entries;
+- create `KEY=value` entries.
+
+Builtins such as `export`, `unset` and `cd` modify this shell-owned environment.
+
+### `last_status`
+
+`last_status` stores the result of the most recently executed command or
+pipeline.
+
+It is also the source used when expanding `$?`.
+
+### `should_exit`
+
+`should_exit` allows the `exit` builtin to request termination of the
+interactive session without bypassing normal session cleanup.
+
+## Persistent and Transient State
+
+A central architectural boundary is the distinction between session-persistent
+state and objects created for one command line.
+
+### Persistent state
+
+```text
+t_shell
+└── envp
+    last_status
+    should_exit
+```
+
+This state survives across prompt iterations.
+
+### Per-line state
+
+```text
+readline input
+      |
+      v
+t_token list
+      |
+      v
+t_cmd chain
+      |
+      +-- argv
+      |
+      +-- t_redir list
+```
+
+These objects exist only for the processing and execution of one input line and
+are released before the next command is processed.
+
+Execution may additionally create short-lived child processes, pipes, heredoc
+pipes and redirection file descriptors.
+
+## Input Representation
+
+### Tokens
+
+The scanner represents lexical output using `t_token`:
+
+```c
+typedef struct s_token
+{
+    t_toktype       type;
+    char            *value;
+    struct s_token  *next;
+}   t_token;
+```
+
+Supported token types are:
+
+- `TOK_WORD`;
+- `TOK_PIPE`;
+- `TOK_REDIR_IN`;
+- `TOK_REDIR_OUT`;
+- `TOK_HEREDOC`;
+- `TOK_APPEND`.
+
+Operators do not require string values.
+
+Word tokens own the strings produced by scanning and expansion.
+
+## Scanning and Expansion
+
+The scanner processes the input line while preserving enough context to
+distinguish:
+
+- unquoted text;
+- single-quoted text;
+- double-quoted text;
+- shell operators.
+
+Expansion behaviour is determined while each word is being assembled:
+
+| Input context | Variable expansion |
+| --- | --- |
+| unquoted segment | yes |
+| single-quoted segment | no |
+| double-quoted segment | yes |
+
+The expansion subsystem currently handles:
+
+- `$NAME`;
+- `$?`;
+- literal `$` when it is not followed by a valid expansion target.
+
+After scanning, quote delimiters are no longer represented explicitly in the
+token model.
+
+This is why expansion belongs to the scanning stage in the maintained
+implementation.
+
+## Command Representation
+
+The grammar subsystem converts the token stream into a linked list of `t_cmd`
+objects:
+
+```c
+typedef struct s_cmd
+{
+    char            **argv;
+    int             argc;
+    t_redir         *redirs;
+    struct s_cmd    *next;
+}   t_cmd;
+```
+
+Each node represents one command stage.
+
+A pipeline is represented by linking multiple command nodes:
+
+```text
+t_cmd -> t_cmd -> t_cmd -> NULL
+```
+
+There is no separate pipeline object and no general shell AST in the maintained
+implementation.
+
+### Arguments
+
+Word tokens that are not redirection targets are copied into the command's
+null-terminated `argv` array.
+
+The command representation owns these copies independently of the token list.
+
+### Redirections
+
+Redirections are represented separately from command arguments:
+
+```c
+typedef struct s_redir
+{
+    t_toktype       type;
+    char            *target;
+    int             fd;
+    struct s_redir  *next;
+}   t_redir;
+```
+
+The grammar preserves redirections in source order.
+
+Each redirection stores:
+
+- its operator type;
+- an owned copy of its target;
+- an optional prepared file descriptor;
+- a link to the next redirection.
+
+The `fd` field starts at `-1` and may temporarily own a descriptor prepared for
+execution.
+
+Detailed descriptor ownership is covered by `resource-ownership.md`.
+
+## Execution Boundary
+
+After grammar construction, the session dispatches according to the number of
+commands:
+
+```text
+one t_cmd
+    |
+    v
+exe_simple()
+
+multiple t_cmd nodes
+    |
+    v
+exe_pipeline()
+```
+
+The execution subsystem is responsible for:
+
+- standalone command execution;
+- child-process creation;
+- external command resolution;
+- pipeline construction;
+- redirection preparation and application;
+- heredoc collection;
+- child waiting;
+- exit-status conversion.
+
+Standalone builtins execute in the parent shell so that changes to persistent
+state can survive the command.
+
+Builtins used as pipeline stages execute in child processes, so state changes
+remain local to the child.
+
+## Builtin Boundary
+
+The builtin subsystem supports:
+
+- `echo`;
+- `pwd`;
+- `env`;
+- `export`;
+- `unset`;
+- `cd`;
+- `exit`.
+
+`blt_execute()` provides common dispatch.
+
+The execution context determines whether that dispatch occurs in the persistent
+parent shell or in a child process.
+
+This distinction is especially important for stateful builtins such as `cd`,
+`export`, `unset` and `exit`.
+
+## External Commands
+
+External commands eventually execute through `execve()`.
+
+Commands containing `/` are treated as direct paths.
+
+Commands without `/` are resolved through the shell-owned `PATH` environment
+value before execution.
+
+Execution error handling and status conversion remain responsibilities of the
+execution subsystem rather than the PATH lookup helper.
+
+## Runtime Working Contexts
+
+In addition to the main persistent and command data structures, the
+implementation uses small context structures for localized runtime work.
+
+### `t_tokctx`
+
+Carries scanner state while processing one input line:
+
+- source line;
+- current index;
+- token-list head;
+- shell state;
+- error state.
+
+### `t_child_ctx`
+
+Carries references to command and session resources used during execution and
+for child-local cleanup:
+
+- command-chain pointer;
+- token-list pointer;
+- shell-state pointer.
+
+This context allows execution children to release their inherited process-local
+copies before exit.
+
+### `t_pipe_state`
+
+Tracks the rolling state required while constructing a pipeline:
+
+- previous-stage read descriptor;
+- current pipe descriptors;
+- PID of the most recently launched stage.
+
+The pipeline therefore does not require a persistent array containing all pipe
+pairs.
+
+## Signal Boundary
+
+Signal behaviour depends on the current runtime context rather than using one
+global policy for every process state.
+
+The implementation distinguishes policies for:
+
+- interactive input;
+- a parent waiting for foreground children;
+- execution children;
+- heredoc input.
+
+Detailed process and signal behaviour is documented in
+`process-and-signals.md`.
+
+## Architecture Constraints
+
+The current architecture intentionally reflects the implemented project scope.
+
+In particular:
+
+- the grammar represents command chains rather than a general-purpose shell
+  syntax tree;
+- expansion is integrated with scanning;
+- the environment is stored directly as an owned `char **`;
+- pipeline construction uses rolling descriptor state;
+- heredoc body variable expansion is not implemented in the current baseline;
+- optional syntax such as `&&`, `||`, parentheses and wildcard expansion is
+  outside the maintained baseline.
+
+These constraints describe the current implementation and should not be
+interpreted as requirements for future extensions.
+
+## Historical Design Material
+
+Earlier design documents are preserved under:
+
+[`../history/design/`](../history/design/)
+
+They remain useful for understanding the development process but are not the
+authoritative description of the maintained architecture.
+
+Where those documents disagree with this documentation, the current source code
+and maintained architecture documentation take precedence.


### PR DESCRIPTION
## Summary

Documents the current, source-verified Minishell architecture and replaces the
placeholder architecture section with maintained as-built documentation.

Closes #31.

Parent: #26.

## Changes

- add a maintained system overview and subsystem map;
- document the end-to-end command lifecycle from prompt to exit status;
- document the actual scan-time, quote-aware expansion model;
- document the linked `t_cmd` pipeline representation;
- document simple-command and rolling pipeline execution paths;
- document standalone-parent versus pipeline-child builtin execution;
- document redirection ordering and pipeline/redirection interaction;
- document heredoc preparation and current heredoc expansion limitation;
- document parent, execution-child and heredoc process roles;
- document context-specific signal policies;
- document memory and file-descriptor ownership and transfer boundaries;
- replace the architecture placeholder README with maintained navigation and
  source-of-truth rules;
- preserve earlier design material under `docs/history/design/`.

## Architecture Model

The maintained runtime is documented as:

`readline → scan + quote-aware expansion → token list → grammar → linked command chain → simple/pipeline execution → status → persistent shell state`

The documentation follows the final source implementation rather than earlier
design intentions.

## Historical Differences

The source audit confirmed several differences from development-stage design
material, including scan-time expansion, linked command-chain pipeline
representation, direct `char **` environment ownership in `t_shell`, rolling
pipeline descriptor state and evolved source-module boundaries.

Historical documentation remains preserved for provenance and is not rewritten
by this change.

## Validation

- source architecture audited across all maintained source domains;
- local Markdown links validated;
- Markdown code fences validated;
- stale documentation references checked;
- architecture acceptance coverage checked;
- `git diff --check main...HEAD` passes;
- no source-code or behaviour changes are included.

## Scope

Documentation only.

No command behaviour, source implementation, build configuration or project
features are changed by this PR.