### PR TITLE
docs(decisions): document key engineering decisions

### DIFF
--- a/docs/decisions/ADR-0001-expand-while-scanning.md
+++ b/docs/decisions/ADR-0001-expand-while-scanning.md
@@ -1,0 +1,221 @@
+# ADR-0001: Perform variable expansion while quote context is available
+
+- **Status:** Accepted
+- **Recorded:** 2026-08-26
+- **Decision scope:** Maintained implementation
+- **Rationale provenance:** Supported by preserved development material and the final source implementation
+
+## Context
+
+Minishell must interpret environment-variable references and the previous exit
+status differently depending on quoting context.
+
+The maintained implementation distinguishes three relevant word-segment
+contexts:
+
+- unquoted text;
+- single-quoted text;
+- double-quoted text.
+
+Their expansion behaviour is different:
+
+| Context | Variable expansion |
+| --- | --- |
+| Unquoted text | Yes |
+| Single-quoted text | No |
+| Double-quoted text | Yes |
+
+The scanner also removes quote delimiters while constructing the final word.
+
+Once those delimiters have been discarded, a later processing stage cannot
+reliably determine whether characters in the resulting word originally came
+from unquoted, single-quoted or double-quoted input.
+
+The expansion decision therefore depends on lexical context that exists during
+scanning but is not preserved in the resulting token model.
+
+## Decision
+
+Perform mandatory variable expansion while word segments are being scanned and
+their quote context is still known.
+
+The maintained flow is conceptually:
+
+```text
+input line
+    |
+    v
+scan word
+    |
+    +--> unquoted segment
+    |       |
+    |       `--> expand variables
+    |
+    +--> single-quoted segment
+    |       |
+    |       `--> preserve literally
+    |
+    `--> double-quoted segment
+            |
+            `--> expand variables
+    |
+    v
+assembled TOK_WORD
+```
+
+Expansion is therefore part of word construction rather than a separate pass
+over parsed commands.
+
+The resulting token contains the already processed word value needed by the
+grammar and execution layers.
+
+## Rationale
+
+The decision keeps expansion at the point where the implementation still knows
+how each source segment was quoted.
+
+This allows the scanner to apply the required distinction directly:
+
+```text
+unquoted       -> expansion
+single quoted  -> literal content
+double quoted  -> expansion
+```
+
+The preserved `MSH-12` expansion documentation explicitly records this
+rationale: expansion occurs during tokenization because quote characters are
+removed by that stage, and postponing expansion would lose the information
+needed to distinguish the original quote context.
+
+The final source retains the same architectural property.
+
+`scn_word()` dispatches segment handling according to lexical context.
+Unquoted segments are expanded through `exp_variables()`.
+
+`scn_quote_single()` returns literal quoted content without variable
+expansion.
+
+`scn_quote_double()` processes the double-quoted segment through
+`exp_variables()` before returning it to word construction.
+
+The grammar therefore receives word tokens whose mandatory variable expansion
+has already been resolved.
+
+## Alternatives Considered
+
+### Separate expansion after parsing
+
+Earlier preserved architecture material described the conceptual lifecycle as:
+
+```text
+readline -> tokenize -> parse -> expand -> execute
+```
+
+Under that model, expansion would operate on parsed command words and
+redirection operands after lexical processing.
+
+This separation has an attractive subsystem boundary: tokenization performs
+lexical analysis, parsing constructs command structures, and expansion then
+transforms those structures before execution.
+
+However, the final scanner does not retain quote-origin metadata after it
+removes the quote delimiters.
+
+A separate later expansion stage would therefore require additional
+representation state, such as quote metadata attached to tokens or parsed word
+segments, in order to preserve the same semantics correctly.
+
+The maintained implementation instead resolves expansion before that
+information disappears.
+
+### Preserve quote metadata for later expansion
+
+Another possible architecture would retain enough quote information in the
+token or command representation for a later expansion phase.
+
+That could preserve a formally separate expansion subsystem.
+
+The maintained implementation does not use such a representation.
+
+Introducing it would increase the amount of transient parsing state and change
+the current token-to-command data model without being required for the
+mandatory implementation.
+
+This is an architectural alternative inferred from the representation
+constraints, not a preserved claim that it was formally debated during the
+original project.
+
+## Consequences
+
+### Positive
+
+- quote-sensitive expansion is resolved while the required lexical context is
+  directly available;
+- single-quoted content can remain literal without reconstructing quote
+  history later;
+- grammar operates on already expanded `TOK_WORD` values;
+- execution does not need a separate mandatory variable-expansion phase;
+- the token and command models do not need to preserve general quote metadata;
+- the implementation boundary is straightforward to trace from source input to
+  final word value.
+
+### Trade-offs
+
+- scanning and expansion are architecturally coupled;
+- lexical processing is responsible for more than token classification alone;
+- adding expansion features that require parsed command context may not fit
+  naturally into the same stage;
+- the implementation differs from a conventional architecture where lexing,
+  parsing and expansion are fully separate passes;
+- future features that require quote metadata after scanning would need either
+  additional representation state or a revised expansion boundary.
+
+## Evidence
+
+### Final implementation
+
+The maintained source verifies the decision through:
+
+- `src/scan/word_scan.c`
+  - `scn_word()`;
+  - unquoted segment processing through `exp_variables()`;
+- `src/scan/quote_scan.c`
+  - `scn_quote_single()`;
+  - `scn_quote_double()`;
+- `src/expand/variables.c`
+  - `exp_variables()`;
+- `include/minishell.h`
+  - scanner and expansion interfaces.
+
+The final scanner expands unquoted and double-quoted segments while preserving
+single-quoted segments literally.
+
+No separate post-grammar mandatory variable-expansion pass exists in the
+maintained runtime.
+
+### Preserved development material
+
+`docs/history/design/MSH-12-expansion-flow.md` explicitly records that
+expansion happens during tokenization while quote context is still available.
+
+It also explains that tokenization removes quote characters, making that timing
+important for preserving the distinction between unquoted, single-quoted and
+double-quoted input.
+
+Earlier `docs/history/design/minishell-architecture.md` described expansion as
+a separate stage after parsing.
+
+Together, these documents preserve both the earlier architectural model and
+the rationale for the implemented flow that replaced it.
+
+## References
+
+Maintained architecture:
+
+- [`../architecture/system-overview.md`](../architecture/system-overview.md)
+- [`../architecture/runtime-flow.md`](../architecture/runtime-flow.md)
+
+Preserved development material:
+
+- [`../history/design/MSH-12-expansion-flow.md`](../history/design/MSH-12-expansion-flow.md)
+- [`../history/design/minishell-architecture.md`](../history/design/minishell-architecture.md)

--- a/docs/decisions/ADR-0002-use-linked-command-pipelines.md
+++ b/docs/decisions/ADR-0002-use-linked-command-pipelines.md
@@ -1,0 +1,235 @@
+# ADR-0002: Represent pipelines as linked command chains
+
+- **Status:** Accepted
+- **Recorded:** 2026-08-26
+- **Decision scope:** Maintained implementation
+- **Rationale provenance:** Supported by preserved development material and the final source implementation
+
+## Context
+
+The mandatory Minishell grammar needs to represent commands connected by
+pipelines and commands containing ordered redirections.
+
+It does not require the maintained mandatory implementation to model a general
+shell expression language with operator precedence, grouped expressions or
+nested boolean operators.
+
+The relevant command structure is therefore fundamentally linear:
+
+```text
+command
+   |
+   v
+command
+   |
+   v
+command
+```
+
+Each command must retain its own:
+
+- argument vector;
+- argument count;
+- ordered redirection list;
+- link to the next pipeline command.
+
+A general abstract syntax tree could represent this grammar, but it would add a
+more expressive structural model than the maintained mandatory execution path
+requires.
+
+## Decision
+
+Represent a pipeline directly as a linked chain of `t_cmd` nodes.
+
+The maintained command type is conceptually:
+
+```text
+t_cmd
+├── argv
+├── argc
+├── redirs
+└── next
+      |
+      v
+    t_cmd
+      |
+      v
+    t_cmd
+```
+
+`grm_pipeline()` constructs this chain by splitting the token stream at pipe
+tokens and creating one command node for each pipeline stage.
+
+There is no separate maintained `t_pipeline` container and no general AST.
+
+Execution receives the first `t_cmd` node and traverses the linked command
+chain.
+
+## Rationale
+
+The preserved design material explicitly preferred a linear command-list model
+over a full AST for the mandatory project scope.
+
+The mandatory grammar does not require precedence relationships between several
+classes of expression operators.
+
+Instead, the core structural relationship is:
+
+```text
+pipeline
+    |
+    +--> command
+    +--> command
+    `--> command
+```
+
+with redirections attached to the individual command they affect.
+
+A linked command chain represents that relationship directly.
+
+This keeps the grammar-to-execution handoff small:
+
+```text
+tokens
+   |
+   v
+grm_pipeline()
+   |
+   v
+linked t_cmd chain
+   |
+   v
+simple or pipeline execution
+```
+
+The final implementation simplified the preserved architecture further.
+
+Historical design material described the possibility of a `t_pipeline`
+structure containing command nodes.
+
+The maintained source does not retain that wrapper. The `t_cmd` links
+themselves provide the pipeline sequence needed by execution.
+
+The architectural decision that survives is therefore the use of a linear,
+AST-less command representation rather than the exact historical container
+shape.
+
+## Alternatives Considered
+
+### Full abstract syntax tree
+
+The preserved architecture material explicitly considered the distinction
+between an AST and a simpler command-list representation.
+
+A full AST would become useful when the grammar must encode relationships such
+as:
+
+```text
+AND / OR precedence
+parenthesized groups
+nested expressions
+pipeline expressions used as tree leaves
+```
+
+That representation would allow execution to recursively evaluate a richer
+shell grammar.
+
+For the maintained mandatory scope, those relationships are not represented.
+
+Using a full AST would therefore introduce node types, recursive traversal and
+additional ownership rules that are not required by the implemented grammar.
+
+The preserved design material intentionally kept those concerns outside the
+mandatory parser.
+
+### Separate `t_pipeline` container
+
+Earlier architecture material described a possible `t_pipeline` structure that
+would contain or reference the command sequence.
+
+This preserves a distinct type for the pipeline abstraction and can provide a
+place for pipeline-wide metadata.
+
+The final implementation does not require such a container.
+
+Pipeline-wide execution state that is needed at runtime is represented
+separately by execution-specific structures such as `t_pipe_state`, while the
+parsed pipeline itself remains a linked `t_cmd` chain.
+
+Removing the wrapper reduces one level of representation without changing the
+linear execution semantics.
+
+## Consequences
+
+### Positive
+
+- the parsed representation closely matches the mandatory grammar;
+- pipeline order is explicit through `t_cmd->next`;
+- each command owns its own arguments and redirections;
+- grammar construction does not require general AST node machinery;
+- execution can traverse pipeline stages directly;
+- simple commands and pipeline stages use the same command representation;
+- ownership and cleanup remain straightforward through one linked command
+  chain.
+
+### Trade-offs
+
+- the representation is specialized for linear pipelines;
+- richer expression grammar cannot be represented naturally by `t_cmd->next`
+  alone;
+- adding boolean operators, grouped expressions or precedence would require a
+  higher-level representation;
+- pipeline-wide parsed metadata has no dedicated container and must either be
+  derived from the chain or represented separately at execution time;
+- the final representation differs from historical diagrams that included a
+  distinct `t_pipeline` type.
+
+## Evidence
+
+### Final implementation
+
+The maintained source verifies the decision through:
+
+- `include/minishell.h`
+  - `t_cmd` contains `struct s_cmd *next`;
+  - no maintained `t_pipeline` type exists;
+- `src/grammar/command_build.c`
+  - creates individual `t_cmd` nodes;
+- `src/grammar/command_chain.c`
+  - appends command nodes;
+  - `grm_pipeline()` builds the complete linked command chain;
+  - `grm_count()` counts commands by traversing that chain;
+- `src/grammar/command_memory.c`
+  - `grm_clear()` destroys the linked command representation;
+- `src/exec/pipeline.c`
+  - pipeline execution traverses the resulting command chain.
+
+No general AST is constructed in the maintained mandatory runtime.
+
+### Preserved development material
+
+`docs/history/design/decisions.md` records an AST-less command-list model for
+mandatory parsing.
+
+`docs/history/design/minishell-architecture.md` states that the mandatory
+implementation should prefer a linear pipeline model over a complex AST and
+explains that the mandatory syntax does not require general operator
+precedence.
+
+That material also describes a possible `t_pipeline` representation.
+
+The final implementation preserves the linear, AST-less architectural choice
+while simplifying the concrete representation to a direct linked `t_cmd`
+chain.
+
+## References
+
+Maintained architecture:
+
+- [`../architecture/system-overview.md`](../architecture/system-overview.md)
+- [`../architecture/runtime-flow.md`](../architecture/runtime-flow.md)
+
+Preserved development material:
+
+- [`../history/design/decisions.md`](../history/design/decisions.md)
+- [`../history/design/minishell-architecture.md`](../history/design/minishell-architecture.md)

--- a/docs/decisions/ADR-0003-run-standalone-builtins-in-parent.md
+++ b/docs/decisions/ADR-0003-run-standalone-builtins-in-parent.md
@@ -1,0 +1,285 @@
+# ADR-0003: Execute standalone builtins in the parent shell
+
+- **Status:** Accepted
+- **Recorded:** 2026-08-26
+- **Decision scope:** Maintained implementation
+- **Rationale provenance:** Supported by preserved development material and the final source implementation
+
+## Context
+
+Some shell builtins modify state that must survive after the command completes.
+
+Examples in the maintained implementation include:
+
+- `cd`, which changes the shell's working directory and updates `PWD` and
+  `OLDPWD`;
+- `export`, which modifies the shell environment;
+- `unset`, which removes variables from the shell environment;
+- `exit`, which updates the persistent shell exit state.
+
+If such a builtin executes only inside a forked child process, its memory and
+process-state changes disappear when that child terminates.
+
+The shell therefore needs an execution context that distinguishes standalone
+builtins from commands executed as pipeline stages.
+
+Parent execution introduces another requirement.
+
+A standalone builtin may contain redirections:
+
+```text
+export NAME=value > output
+cd /tmp > log
+```
+
+Applying those redirections directly to the persistent shell without restoring
+its standard descriptors would affect later commands and the interactive
+prompt.
+
+## Decision
+
+Execute standalone builtins directly in the persistent parent shell.
+
+The maintained simple-command dispatch is conceptually:
+
+```text
+simple command
+      |
+      v
+prepare redirections
+      |
+      +--> no argv
+      |       `--> redirection-only parent path
+      |
+      +--> builtin
+      |       `--> execute in parent
+      |
+      `--> external command
+              `--> fork execution child
+```
+
+All standalone builtins use the parent execution wrapper.
+
+When parent execution requires redirections, preserve the shell's standard
+streams through a save/apply/restore sequence:
+
+```text
+parent STDIN / STDOUT
+        |
+        v
+      dup()
+        |
+        v
+ saved descriptors
+        |
+        v
+apply command redirections
+        |
+        v
+execute builtin
+        |
+        v
+restore with dup2()
+        |
+        v
+close saved descriptors
+```
+
+When a builtin is part of a pipeline, execute it in the pipeline child instead.
+
+Its state changes are therefore local to that child and do not mutate the
+persistent parent shell.
+
+## Rationale
+
+Persistent shell state belongs to the interactive parent process.
+
+Executing state-changing standalone builtins there allows their effects to
+survive into subsequent prompt iterations.
+
+The relationship is direct:
+
+```text
+standalone cd
+      |
+      v
+parent process
+      |
+      +--> chdir()
+      +--> update PWD / OLDPWD
+      |
+      v
+next prompt observes new state
+```
+
+The same principle applies to environment mutation and session exit state.
+
+The preserved architecture material explicitly identifies `cd`, `export`,
+`unset` and `exit` as builtins that require parent execution when used
+standalone.
+
+It also records that parent-run builtins may require temporary redirections and
+that the original standard descriptors must be restored afterward.
+
+The final implementation generalizes the standalone path slightly further:
+all recognized standalone builtins execute through `blt_execute_parent()`,
+including builtins such as `echo`, `pwd` and `env` that do not normally require
+persistent state mutation.
+
+This gives standalone builtin dispatch one consistent execution path.
+
+Pipeline semantics create the opposite boundary.
+
+A builtin in a pipeline must behave as one process stage in concurrent
+process-style data flow.
+
+Executing it in the pipeline child naturally gives it the required pipe
+endpoints while preventing state mutations from leaking back into the
+interactive parent.
+
+## Alternatives Considered
+
+### Execute every builtin in a child
+
+A uniform child-only model would simplify process dispatch because builtins and
+external commands could always use the same forked execution context.
+
+It would also isolate command redirections naturally inside the child.
+
+However, changes made by stateful builtins would disappear when the child exits.
+
+For example:
+
+```text
+cd /tmp
+```
+
+would not change the working directory of the interactive shell.
+
+Likewise, standalone `export`, `unset` and `exit` would fail to persist their
+intended shell-state effects.
+
+This alternative is incompatible with the required behaviour of stateful
+standalone builtins.
+
+### Execute pipeline builtins in the parent
+
+Another possible model would attempt to preserve builtin state by executing
+pipeline builtins in the interactive parent.
+
+That would complicate pipeline execution because a pipeline stage must
+participate in concurrent descriptor-based data flow with neighboring stages.
+
+It would also allow state-changing builtins inside pipelines to mutate the
+persistent shell unexpectedly.
+
+The preserved architecture material explicitly chose child execution for
+builtins used as pipeline stages.
+
+### Apply parent redirections without restoration
+
+Parent execution could apply command redirections directly and leave the
+modified descriptors in place.
+
+That would make the implementation smaller locally, but the redirections would
+survive beyond the builtin invocation.
+
+Later prompts and commands could inherit redirected `stdin` or `stdout`.
+
+The maintained implementation therefore treats parent redirections as a
+temporary execution scope rather than persistent shell state.
+
+## Consequences
+
+### Positive
+
+- standalone stateful builtins can modify persistent shell state;
+- `cd`, `export`, `unset` and `exit` have effects visible after the command
+  finishes;
+- all standalone builtins share one consistent parent dispatch path;
+- pipeline builtins participate naturally as child process stages;
+- state mutations made inside pipeline builtins remain process-local;
+- temporary parent redirections do not leak into later commands;
+- builtin execution preserves the same command redirection semantics available
+  to other command forms.
+
+### Trade-offs
+
+- builtin execution depends on command context rather than builtin identity
+  alone;
+- the persistent parent must temporarily manipulate its own standard file
+  descriptors;
+- save/apply/restore introduces failure paths that child-only execution would
+  avoid;
+- standalone builtin execution and pipeline builtin execution follow different
+  process lifetimes;
+- developers must reason carefully about whether a builtin invocation is
+  expected to mutate persistent or child-local shell state.
+
+## Evidence
+
+### Final implementation
+
+The maintained source verifies the decision through:
+
+- `src/exec/command_simple.c`
+  - standalone builtin detection dispatches to `blt_execute_parent()`;
+  - external simple commands use a forked child path;
+- `src/builtins/parent.c`
+  - `blt_execute_parent()` saves parent standard descriptors;
+  - applies command redirections;
+  - executes the builtin;
+  - restores the saved descriptors;
+- `src/exec/stdio_backup.c`
+  - `exe_stdio_save()`;
+  - `exe_stdio_restore()`;
+- `src/exec/pipeline_child.c`
+  - pipeline stages execute through child context;
+- `src/exec/child_command.c`
+  - builtins reached through child execution use `blt_execute()`;
+- `src/builtins/cd.c`;
+- `src/builtins/export.c`;
+- `src/builtins/unset.c`;
+- `src/builtins/exit.c`.
+
+The final implementation runs every recognized standalone builtin through the
+parent wrapper.
+
+Builtins used as pipeline stages execute inside pipeline children.
+
+### Preserved development material
+
+`docs/history/design/minishell-architecture.md` explicitly distinguishes
+builtin execution contexts.
+
+It records that standalone `cd`, `export`, `unset` and `exit` must run in the
+parent when their state changes need to persist.
+
+The same material records that parent execution may require temporary
+redirections using the sequence:
+
+```text
+save stdin/stdout
+apply redirections
+run builtin
+restore stdin/stdout
+```
+
+It also records that builtins used as pipeline stages should execute in child
+processes so that pipeline data flow remains process-based and state-changing
+side effects do not incorrectly mutate the parent shell.
+
+The final implementation preserves these architectural boundaries while using
+the parent wrapper for all standalone builtins.
+
+## References
+
+Maintained architecture:
+
+- [`../architecture/runtime-flow.md`](../architecture/runtime-flow.md)
+- [`../architecture/process-and-signals.md`](../architecture/process-and-signals.md)
+- [`../architecture/resource-ownership.md`](../architecture/resource-ownership.md)
+
+Preserved development material:
+
+- [`../history/design/minishell-architecture.md`](../history/design/minishell-architecture.md)

--- a/docs/decisions/ADR-0004-use-rolling-pipeline-state.md
+++ b/docs/decisions/ADR-0004-use-rolling-pipeline-state.md
@@ -1,0 +1,260 @@
+# ADR-0004: Manage pipelines with rolling descriptor state
+
+- **Status:** Accepted
+- **Recorded:** 2026-08-26
+- **Decision scope:** Maintained implementation
+- **Rationale provenance:** Reconstructed from the final implementation and preserved alternatives
+
+## Context
+
+Executing a pipeline requires each command stage to receive the appropriate
+input and output endpoints while unused pipe descriptors are closed promptly.
+
+For a pipeline such as:
+
+```text
+producer | transform | consumer
+```
+
+the shell must coordinate:
+
+- the read endpoint inherited from the previous stage;
+- the pipe created for the next stage;
+- the PID of the final stage whose status determines the pipeline result;
+- closure of descriptors that the parent and children no longer need.
+
+One possible implementation strategy is to allocate and retain all `N - 1`
+pipes for an `N`-command pipeline before launching the command processes.
+
+The maintained implementation instead traverses the linked command chain from
+left to right and keeps only the pipeline descriptor state required for the
+current transition.
+
+## Decision
+
+Manage pipeline construction using a rolling `t_pipe_state`.
+
+The maintained state is conceptually:
+
+```text
+t_pipe_state
+├── prev_fd
+├── pipefd[2]
+└── last_pid
+```
+
+where:
+
+```text
+prev_fd
+    read endpoint produced by the previous pipeline stage
+
+pipefd[0]
+    read endpoint of the pipe created for the current stage transition
+
+pipefd[1]
+    write endpoint of the pipe created for the current stage transition
+
+last_pid
+    PID of the most recently launched stage, which becomes the final-stage PID
+    after pipeline construction completes
+```
+
+Pipeline construction advances one command at a time.
+
+For each command:
+
+```text
+current command
+      |
+      +--> create next pipe if another command follows
+      |
+      +--> fork current stage
+      |
+      +--> remember child PID
+      |
+      +--> close previous parent read endpoint
+      |
+      +--> close current parent write endpoint
+      |
+      `--> retain current read endpoint as next prev_fd
+```
+
+The parent therefore carries only the descriptor state needed to connect the
+next command.
+
+## Rationale
+
+The final implementation clearly establishes rolling pipeline state, but the
+specific original rationale for choosing this form was not preserved
+contemporaneously.
+
+The rationale recorded here is therefore reconstructed from the resulting
+architecture and from the alternative pipeline model preserved in earlier
+design material.
+
+The rolling representation matches the final parsed command model closely.
+
+Commands are already represented as a left-to-right linked `t_cmd` chain, so
+pipeline construction can consume that chain incrementally:
+
+```text
+t_cmd
+  |
+  v
+launch
+  |
+  v
+advance state
+  |
+  v
+next t_cmd
+```
+
+At each step, the parent only needs:
+
+```text
+previous read end
+current pipe pair
+current last PID
+```
+
+Once a child has inherited the descriptors required for its stage, the parent
+can close descriptors that no longer participate in later pipeline
+construction.
+
+This keeps descriptor lifetime explicit and local to the command transition
+that uses it.
+
+It also avoids requiring a separate pipeline-wide array of all pipe pairs in
+the maintained implementation.
+
+These are architectural consequences and reasonable motivations inferred from
+the final design.
+
+They are not presented as confirmed historical reasons for the original
+implementation choice.
+
+## Alternatives Considered
+
+### Pre-create all `N - 1` pipes
+
+Preserved architecture material described the pipeline conceptually as:
+
+```text
+for N commands:
+    create N - 1 pipes
+    connect each child to the required pipe endpoints
+    close unused descriptors
+    wait for all children
+```
+
+This is a common and valid pipeline representation.
+
+It makes the complete descriptor topology available before any command child
+is launched.
+
+It can also make stage-to-pipe indexing explicit because all pipe pairs exist
+in one pipeline-wide structure.
+
+The maintained implementation does not use this model.
+
+Instead, it creates the next pipe only when another command follows and carries
+the resulting read endpoint forward through `prev_fd`.
+
+### Store all pipeline descriptors in a dynamic structure
+
+Another possible design would allocate an array or other container for every
+pipe descriptor in the pipeline.
+
+That could centralize pipeline-wide cleanup and make arbitrary descriptor
+lookup possible.
+
+The final implementation does not require arbitrary access to earlier pipe
+pairs once a stage has been launched.
+
+A rolling state therefore represents the actual traversal needs with less
+persistent execution metadata.
+
+This alternative is an analytical comparison with the final architecture, not
+a preserved claim that a dynamic descriptor container was formally debated
+during the original project.
+
+## Consequences
+
+### Positive
+
+- pipeline construction matches the left-to-right linked command traversal;
+- the parent tracks only the previous read endpoint and current pipe pair;
+- descriptors can be closed as soon as they are no longer required by future
+  stages;
+- execution does not require a pipeline-wide pipe array;
+- descriptor ownership remains localized to the current transition;
+- the final stage PID is tracked naturally while commands are launched;
+- the implementation scales with pipeline length without accumulating all pipe
+  descriptors in one parent-side representation.
+
+### Trade-offs
+
+- the complete pipeline descriptor topology is not available in one structure;
+- execution logic depends on correctly advancing `prev_fd` after every stage;
+- failure cleanup must understand partially advanced rolling state;
+- debugging a complete pipeline can require following descriptor transitions
+  over time rather than inspecting one pre-built pipe table;
+- the model is specialized for sequential left-to-right pipeline construction.
+
+## Evidence
+
+### Final implementation
+
+The maintained source verifies the decision through:
+
+- `include/minishell.h`
+  - `t_pipe_state` contains `prev_fd`, `pipefd[2]` and `last_pid`;
+- `src/exec/pipeline.c`
+  - initializes rolling pipeline state;
+  - creates a new pipe only when another command follows;
+  - forks one stage at a time;
+  - records each launched PID in `last_pid`;
+  - closes the previous read endpoint in the parent;
+  - closes the current write endpoint in the parent;
+  - moves the current read endpoint into `prev_fd`;
+- `src/exec/pipeline_child.c`
+  - duplicates `prev_fd` into standard input when required;
+  - duplicates the current write endpoint into standard output when required;
+  - closes inherited pipeline descriptors after duplication;
+- `src/exec/pipeline_wait.c`
+  - waits for pipeline children;
+  - returns the status associated with `last_pid`.
+
+The maintained source does not allocate an array containing all `N - 1` pipe
+pairs.
+
+### Preserved development material
+
+`docs/history/design/minishell-architecture.md` describes pipeline execution
+conceptually using `N - 1` pipes for `N` commands.
+
+It also records two principles that remain visible in the final
+implementation:
+
+- children should close unused pipe descriptors promptly;
+- the parent should close pipe ends as soon as they are no longer needed.
+
+The preserved document does not record the later transition to the final
+rolling `t_pipe_state` representation or the specific motivation for that
+change.
+
+For that reason, the rationale in this ADR is explicitly retrospective.
+
+## References
+
+Maintained architecture:
+
+- [`../architecture/runtime-flow.md`](../architecture/runtime-flow.md)
+- [`../architecture/process-and-signals.md`](../architecture/process-and-signals.md)
+- [`../architecture/resource-ownership.md`](../architecture/resource-ownership.md)
+
+Preserved development material:
+
+- [`../history/design/minishell-architecture.md`](../history/design/minishell-architecture.md)

--- a/docs/decisions/ADR-0005-prepare-pipeline-heredocs-before-launch.md
+++ b/docs/decisions/ADR-0005-prepare-pipeline-heredocs-before-launch.md
@@ -1,0 +1,287 @@
+# ADR-0005: Prepare pipeline heredocs before launching command children
+
+- **Status:** Accepted
+- **Recorded:** 2026-08-26
+- **Decision scope:** Maintained implementation
+- **Rationale provenance:** Reconstructed from the final implementation and preserved alternatives
+
+## Context
+
+A heredoc is an input redirection whose contents must be collected
+interactively before the consuming command can read from it.
+
+In the maintained implementation, heredoc collection itself requires temporary
+runtime resources:
+
+- a pipe;
+- a dedicated heredoc child;
+- heredoc-specific signal behaviour;
+- a wait operation in the parent;
+- a readable descriptor retained for later command execution.
+
+A pipeline can contain heredocs in more than one command stage.
+
+For example:
+
+```text
+command1 << FIRST | command2 << SECOND | command3
+```
+
+The shell therefore needs to decide when heredoc input is collected relative
+to creation of the actual pipeline command processes.
+
+Launching command children while later heredocs are still being collected
+would mix two different foreground activities:
+
+```text
+pipeline execution
+heredoc acquisition
+```
+
+The maintained implementation avoids that overlap.
+
+## Decision
+
+Prepare every heredoc belonging to the pipeline before launching any pipeline
+command child.
+
+The maintained execution order is conceptually:
+
+```text
+parsed pipeline
+      |
+      v
+walk command chain
+      |
+      +--> prepare heredocs for command 1
+      +--> prepare heredocs for command 2
+      +--> prepare heredocs for command N
+      |
+      v
+all heredoc preparation succeeded?
+      |
+   +--+--+
+   |     |
+  no    yes
+   |     |
+   v     v
+abort   launch pipeline children
+```
+
+Each successfully prepared heredoc leaves a readable descriptor stored in its
+corresponding `t_redir.fd`.
+
+Only after the pipeline-wide heredoc pass succeeds does normal pipeline
+construction begin.
+
+The command child that eventually consumes the heredoc inherits the prepared
+descriptor and applies it through the normal redirection path.
+
+## Rationale
+
+The final implementation clearly establishes a pipeline-wide heredoc
+preparation phase.
+
+The specific original rationale for choosing this order was not preserved
+contemporaneously.
+
+The rationale recorded here is therefore reconstructed from the final process,
+signal and resource-ownership model.
+
+Preparing all heredocs first creates a clean phase boundary:
+
+```text
+interactive heredoc acquisition
+          |
+          v
+prepared redirection resources
+          |
+          v
+pipeline process launch
+```
+
+This means pipeline command children do not begin normal command execution
+while the parent is still collecting later heredoc input.
+
+It also gives heredoc interruption a well-defined failure boundary.
+
+If heredoc preparation is interrupted or otherwise fails, pipeline launch can
+stop before command children are created.
+
+The resulting readable descriptors are prepared resources rather than active
+pipeline topology.
+
+They can remain attached to their `t_redir` nodes until the relevant command
+child applies its redirections.
+
+This fits the maintained redirection ownership model:
+
+```text
+heredoc acquisition
+      |
+      v
+pipe read end
+      |
+      v
+t_redir.fd
+      |
+      | inherited through later fork
+      v
+command child
+      |
+      v
+redirection application
+      |
+      v
+STDIN
+```
+
+These properties are consequences of the final architecture and provide a
+reasonable explanation for the ordering.
+
+They are not presented as confirmed historical motivations for the original
+implementation choice.
+
+## Alternatives Considered
+
+### Prepare each heredoc immediately before its command child
+
+A pipeline could be constructed incrementally so that each stage's heredocs
+are collected immediately before that stage is forked.
+
+Conceptually:
+
+```text
+prepare stage 1 heredocs
+fork stage 1
+
+prepare stage 2 heredocs
+fork stage 2
+
+prepare stage 3 heredocs
+fork stage 3
+```
+
+This could reduce the time between heredoc preparation and consumption.
+
+However, earlier pipeline children could already be running while the shell is
+still performing interactive heredoc acquisition for later stages.
+
+That would couple foreground pipeline execution with readline-driven heredoc
+collection.
+
+It would also make interruption during a later heredoc occur after part of the
+pipeline had already been launched.
+
+The maintained implementation does not use this ordering.
+
+This alternative is an analytical comparison with the final architecture, not
+a preserved claim that this exact launch strategy was formally debated.
+
+### Collect heredocs inside command children
+
+Another possible design would defer heredoc acquisition to the child that
+eventually consumes the input.
+
+That would colocate acquisition and consumption in the same process.
+
+However, heredoc reading requires interactive terminal handling and a
+specialized signal policy before normal command execution.
+
+Performing that interaction independently inside pipeline command children
+would complicate foreground terminal ownership and coordination between
+multiple stages.
+
+The maintained implementation instead gives heredoc acquisition its own
+temporary child process and completes that phase before pipeline command
+children are launched.
+
+This alternative is inferred from the process architecture rather than
+documented as an original design debate.
+
+## Consequences
+
+### Positive
+
+- all interactive heredoc acquisition finishes before pipeline execution
+  begins;
+- interruption during heredoc preparation can abort the pipeline before command
+  children are launched;
+- pipeline command children receive already prepared heredoc descriptors;
+- heredoc resources integrate with the normal `t_redir.fd` ownership model;
+- heredoc-specific signal handling remains separate from normal execution-child
+  signal behaviour;
+- pipeline launch operates on a fully prepared set of heredoc inputs;
+- command execution does not need to invoke readline for heredoc acquisition.
+
+### Trade-offs
+
+- every pipeline heredoc must be collected before any command stage begins
+  executing;
+- prepared heredoc descriptors can remain open across subsequent heredoc
+  collection until pipeline launch;
+- the execution layer requires a distinct pipeline-wide heredoc pre-pass;
+- heredoc preparation and normal file-redirection preparation do not follow
+  exactly the same pipeline timing;
+- the model introduces additional process and descriptor lifecycle steps before
+  the first pipeline command child is launched.
+
+## Evidence
+
+### Final implementation
+
+The maintained source verifies the decision through:
+
+- `src/exec/pipeline_wait.c`
+  - pipeline heredoc preparation traverses command stages before normal
+    pipeline launch proceeds;
+  - `exe_heredocs_prepare()` is invoked for commands during that pre-pass;
+- `src/exec/redir_prepare.c`
+  - `exe_heredocs_prepare()` prepares heredoc redirections;
+  - successful preparation stores the resulting readable descriptor in the
+    corresponding redirection;
+- `src/exec/heredoc.c`
+  - creates the heredoc pipe;
+  - forks the dedicated heredoc child;
+  - waits for heredoc completion in the parent;
+  - retains the pipe read end when preparation succeeds;
+- `src/exec/heredoc_read.c`
+  - performs heredoc input collection;
+- `src/exec/heredoc_terminal.c`
+  - saves and restores terminal state around heredoc acquisition;
+- `src/exec/pipeline.c`
+  - launches pipeline command children only after the preceding pipeline
+    preparation path succeeds;
+- `include/minishell.h`
+  - exposes the heredoc preparation and pipeline execution interfaces.
+
+The final runtime therefore separates pipeline-wide heredoc acquisition from
+pipeline command-process creation.
+
+### Preserved development material
+
+`docs/history/design/minishell-architecture.md` records that heredoc input
+should be prepared before the command that consumes it executes and that the
+result should be represented by a readable descriptor suitable for standard
+input.
+
+The preserved material does not explicitly describe the final policy of
+preparing all heredocs across the entire pipeline before launching any command
+child.
+
+It therefore supports the general preparation-before-execution requirement but
+does not establish the specific rationale for the pipeline-wide pre-pass.
+
+For that reason, the rationale in this ADR is explicitly retrospective.
+
+## References
+
+Maintained architecture:
+
+- [`../architecture/runtime-flow.md`](../architecture/runtime-flow.md)
+- [`../architecture/process-and-signals.md`](../architecture/process-and-signals.md)
+- [`../architecture/resource-ownership.md`](../architecture/resource-ownership.md)
+
+Preserved development material:
+
+- [`../history/design/minishell-architecture.md`](../history/design/minishell-architecture.md)

--- a/docs/decisions/ADR-0006-own-mutable-shell-environment.md
+++ b/docs/decisions/ADR-0006-own-mutable-shell-environment.md
@@ -1,0 +1,386 @@
+# ADR-0006: Maintain an owned mutable environment in shell state
+
+- **Status:** Accepted
+- **Recorded:** 2026-08-26
+- **Decision scope:** Maintained implementation
+- **Rationale provenance:** Reconstructed from the final implementation and preserved alternatives
+
+## Context
+
+Minishell needs environment state that persists across interactive command
+iterations.
+
+That state is used by several parts of the system:
+
+- variable expansion reads environment values;
+- `export` adds or updates entries;
+- `unset` removes entries;
+- `cd` updates `PWD` and `OLDPWD`;
+- external command execution passes an environment to `execve()`;
+- child processes inherit the current shell state at `fork()` time.
+
+The environment received by `main()` is process input rather than an
+application-owned mutable model.
+
+The shell therefore needs to establish what representation owns the persistent
+environment and how mutations are reflected across later commands.
+
+Historical design material considered an explicit environment abstraction such
+as a linked `t_env` structure, with environment arrays potentially created when
+needed for `execve()`.
+
+The maintained implementation uses a different representation.
+
+## Decision
+
+Store the persistent shell environment directly as an owned mutable `char **`
+inside `t_shell`.
+
+The maintained session state is conceptually:
+
+```text
+t_shell
+├── envp
+├── last_status
+└── should_exit
+```
+
+At session initialization:
+
+```text
+process envp
+      |
+      | sta_env_copy()
+      v
+shell->envp
+```
+
+`sta_env_copy()` creates an independent environment array and duplicates its
+entries.
+
+From that point onward, `shell->envp` is the maintained environment source of
+truth.
+
+Environment operations use that representation directly:
+
+```text
+                    shell->envp
+                         |
+          +--------------+--------------+
+          |              |              |
+          v              v              v
+    sta_env_value() sta_env_set() sta_env_unset()
+          |              |              |
+          v              v              v
+      expansion      export / cd       unset
+```
+
+External command execution also uses the current `shell->envp` when invoking
+`execve()`.
+
+## Rationale
+
+The final implementation clearly establishes an owned mutable `char **`
+environment in `t_shell`.
+
+The specific original rationale for choosing this representation over a
+dedicated environment model was not preserved clearly enough to present it as
+historical fact.
+
+The rationale recorded here is therefore reconstructed from the final
+architecture and preserved alternatives.
+
+Using one persistent environment representation creates a direct relationship
+between shell mutation and later consumption:
+
+```text
+builtin mutation
+      |
+      v
+shell->envp
+      |
+      +--> later expansion
+      |
+      +--> later builtin
+      |
+      `--> later execve()
+```
+
+There is no separate persistent linked environment model that must be converted
+back into an `envp` array before external command execution.
+
+The representation also matches the interface required by `execve()`.
+
+That means the environment owned by the interactive shell can be passed
+directly to external programs after the appropriate child process is created.
+
+The state subsystem still encapsulates lookup, insertion and removal logic, so
+the use of `char **` as storage does not require callers to manipulate the
+array structure themselves.
+
+These properties are consequences of the final implementation and provide a
+reasonable architectural rationale for the representation.
+
+They are not presented as confirmed historical motivations for the original
+choice.
+
+## Ownership Model
+
+The initial environment is deep-copied.
+
+Conceptually:
+
+```text
+original process environment
+          |
+          | duplicate array
+          | duplicate entries
+          v
+     shell-owned envp
+```
+
+The persistent shell therefore owns the strings and pointer array associated
+with its environment copy.
+
+Lookup does not transfer ownership.
+
+`sta_env_value()` returns a pointer into the existing environment entry value.
+
+Callers must treat that result as borrowed state.
+
+When an owned expansion result is needed, the expansion layer duplicates the
+value separately.
+
+### Updating an existing entry
+
+When an environment entry is replaced:
+
+```text
+existing entry
+      |
+      v
+free old string
+      |
+      v
+store new owned string
+```
+
+The persistent environment array remains the shell's representation.
+
+### Adding an entry
+
+When a new variable requires a larger array:
+
+```text
+old char ** array
+      |
+      | transfer existing string pointers
+      v
+new char ** array
+      |
+      +--> existing owned strings
+      +--> new owned entry
+      `--> NULL
+```
+
+The old outer pointer array is released after its entries have been
+transferred.
+
+### Removing an entry
+
+When a variable is removed:
+
+```text
+old environment
+      |
+      +--> removed entry -> free
+      |
+      `--> retained entries
+                |
+                | transfer
+                v
+         new char ** array
+```
+
+The environment therefore remains owned by the shell even when the outer array
+changes during mutation.
+
+## Process Boundary
+
+At `fork()`, an execution child inherits a process-local copy of the shell
+state.
+
+Conceptually:
+
+```text
+parent shell->envp
+        |
+        | fork()
+        v
+child-local environment state
+```
+
+A child can pass its inherited `shell->envp` to `execve()`.
+
+Changes made to that environment inside a child process do not mutate the
+persistent parent's copy.
+
+This aligns with the separate execution-context decision documented for
+builtins:
+
+- standalone builtins can mutate the parent environment;
+- pipeline builtins mutate only child-local state.
+
+The persistent source of truth therefore remains with the interactive parent.
+
+## Alternatives Considered
+
+### Dedicated `t_env` representation
+
+Preserved architecture material considered a dedicated environment-storage
+type, potentially represented as linked nodes.
+
+Conceptually:
+
+```text
+t_env
+  |
+  +--> name
+  +--> value
+  +--> export metadata
+  `--> next
+```
+
+Such a model could provide richer typed access to environment state and make
+individual variable operations independent from array reconstruction.
+
+It could also support metadata that does not map directly to `NAME=value`
+strings.
+
+However, external execution ultimately requires an environment array compatible
+with `execve()`.
+
+A separate persistent `t_env` representation would therefore require an
+additional conversion or synchronization boundary.
+
+The maintained implementation does not use that architecture.
+
+### Borrow the original `envp`
+
+Another possible implementation would retain the `envp` received by `main()`
+without creating an owned copy.
+
+That would avoid the initial duplication step.
+
+However, Minishell performs persistent additions, replacements and removals.
+
+An owned representation gives the state subsystem explicit control over the
+lifetime of both the array and its entries.
+
+The maintained implementation therefore establishes ownership during session
+initialization.
+
+This alternative is an analytical comparison with the final architecture, not
+a preserved claim that borrowing the original array was formally debated.
+
+### Maintain separate internal and execution representations
+
+The shell could keep one internal environment model and generate a temporary
+`char **envp` only when launching external commands.
+
+This separates internal state design from the `execve()` interface.
+
+It also introduces a synchronization and allocation boundary each time the
+execution representation must be rebuilt.
+
+The final implementation instead keeps a representation that already matches
+the external execution interface.
+
+Historical design material considered temporary `envp` arrays alongside a
+possible internal environment store, but the maintained source does not retain
+that split.
+
+## Consequences
+
+### Positive
+
+- the shell has one persistent environment source of truth;
+- environment mutations survive across prompt iterations;
+- lookup, insertion and removal operate on the same maintained representation;
+- external commands can receive the current environment directly through
+  `execve()`;
+- no persistent `t_env` to `char **` synchronization layer is required;
+- ownership of environment memory is explicit at session level;
+- child processes naturally inherit a process-local snapshot through `fork()`.
+
+### Trade-offs
+
+- adding and removing variables can require allocation of a new pointer array;
+- entries are represented as `NAME=value` strings rather than richer typed
+  objects;
+- variable lookup requires searching the environment array;
+- metadata not encoded in environment strings would require an additional
+  representation;
+- ownership transfers during array replacement and removal require careful
+  memory management;
+- the persistent environment model is coupled to the conventional `envp`
+  representation expected by process execution.
+
+## Evidence
+
+### Final implementation
+
+The maintained source verifies the decision through:
+
+- `include/minishell.h`
+  - `t_shell` owns a `char **envp` field;
+  - state operations accept or update the shell environment;
+- `src/session/prompt_loop.c`
+  - `ses_init()` initializes `shell->envp` with `sta_env_copy()`;
+- `src/state/env_copy.c`
+  - `sta_env_copy()` creates the initial owned environment copy;
+- `src/state/env_lookup.c`
+  - environment lookup and indexing operate directly on `char **envp`;
+- `src/state/env_set.c`
+  - `sta_env_set()` replaces existing entries or extends the environment
+    array;
+- `src/state/env_unset.c`
+  - `sta_env_unset()` removes entries and replaces the outer environment
+    array;
+- the execution layer passes the maintained shell environment to external
+  command execution.
+
+The final source contains no persistent `t_env` abstraction.
+
+### Preserved development material
+
+`docs/history/design/minishell-architecture.md` considered the environment
+source of truth as either an environment list or environment array.
+
+It also described a possible `t_env` linked representation and temporary
+`envp` arrays for external execution.
+
+The final implementation resolves those alternatives by storing the persistent
+environment directly as an owned `char **` in `t_shell`.
+
+The preserved material does not record the specific original rationale for that
+final representation.
+
+For that reason, the rationale in this ADR is explicitly retrospective.
+
+## References
+
+Maintained architecture:
+
+- [`../architecture/system-overview.md`](../architecture/system-overview.md)
+- [`../architecture/runtime-flow.md`](../architecture/runtime-flow.md)
+- [`../architecture/process-and-signals.md`](../architecture/process-and-signals.md)
+- [`../architecture/resource-ownership.md`](../architecture/resource-ownership.md)
+
+Related decision:
+
+- [`ADR-0003`](ADR-0003-run-standalone-builtins-in-parent.md)
+
+Preserved development material:
+
+- [`../history/design/minishell-architecture.md`](../history/design/minishell-architecture.md)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -236,7 +236,7 @@ the final implementation and preserved design material.
 | --- | --- | --- |
 | [ADR-0001](ADR-0001-expand-while-scanning.md) | Perform variable expansion while quote context is available | Accepted |
 | [ADR-0002](ADR-0002-use-linked-command-pipelines.md) | Represent pipelines as linked command chains | Accepted |
-| ADR-0003 | Execute standalone builtins in the parent shell | Planned |
+| [ADR-0003](ADR-0003-run-standalone-builtins-in-parent.md) | Execute standalone builtins in the parent shell | Accepted |
 | ADR-0004 | Manage pipelines with rolling descriptor state | Planned |
 | ADR-0005 | Prepare pipeline heredocs before launching command children | Planned |
 | ADR-0006 | Maintain an owned mutable environment in shell state | Planned |

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -234,7 +234,7 @@ the final implementation and preserved design material.
 
 | ADR | Decision | Record state |
 | --- | --- | --- |
-| ADR-0001 | Perform variable expansion while quote context is available | Planned |
+| [ADR-0001](ADR-0001-expand-while-scanning.md) | Perform variable expansion while quote context is available | Accepted |
 | ADR-0002 | Represent pipelines as linked command chains | Planned |
 | ADR-0003 | Execute standalone builtins in the parent shell | Planned |
 | ADR-0004 | Manage pipelines with rolling descriptor state | Planned |

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -239,7 +239,7 @@ the final implementation and preserved design material.
 | [ADR-0003](ADR-0003-run-standalone-builtins-in-parent.md) | Execute standalone builtins in the parent shell | Accepted |
 | [ADR-0004](ADR-0004-use-rolling-pipeline-state.md) | Manage pipelines with rolling descriptor state | Accepted |
 | [ADR-0005](ADR-0005-prepare-pipeline-heredocs-before-launch.md) | Prepare pipeline heredocs before launching command children | Accepted |
-| ADR-0006 | Maintain an owned mutable environment in shell state | Planned |
+| [ADR-0006](ADR-0006-own-mutable-shell-environment.md) | Maintain an owned mutable environment in shell state | Accepted |
 
 `Planned` in this table describes documentation progress, not architectural
 status.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,37 +1,322 @@
 # Engineering Decisions
 
-This directory records significant engineering decisions that affect the
-architecture, behaviour, maintainability or development of the project.
+This directory contains Architecture Decision Records (ADRs) for significant
+engineering decisions that shape the maintained Minishell implementation.
 
-Decisions are documented as Architecture Decision Records (ADRs) when the
-reasoning behind them is valuable to future contributors.
+The purpose of these records is to preserve architectural rationale separately
+from implementation documentation.
 
-## ADR Format
+For the current as-built system, see
+[`../architecture/`](../architecture/).
 
-ADR files follow the naming convention:
+Historical development material remains under
+[`../history/`](../history/).
+
+## What Belongs Here
+
+An ADR should document a decision when:
+
+- it materially affects system architecture or runtime behaviour;
+- understanding the rationale helps future maintainers;
+- realistic alternatives existed or remain relevant;
+- the consequences influence later engineering work.
+
+An ADR should not be created merely because an implementation detail exists.
+
+Routine function structure, naming choices and local refactoring decisions
+normally belong in source code, commit history or development documentation
+rather than in this directory.
+
+## Source of Truth
+
+ADRs explain why significant engineering choices exist.
+
+They do not override the implementation.
+
+When resolving discrepancies, use the following precedence:
+
+1. current source code for implemented behaviour;
+2. maintained architecture documentation for the as-built system model;
+3. accepted ADRs for architectural rationale;
+4. historical design material for development provenance.
+
+A historical document may explain an earlier intention without describing the
+final implementation.
+
+## Retrospective Records
+
+The ADR practice was introduced after the original 42 Minishell implementation
+was completed.
+
+The records in this directory may therefore document decisions
+retrospectively.
+
+Each ADR distinguishes between:
+
+- implementation facts verified from the final source tree;
+- rationale supported by preserved development material;
+- rationale reconstructed from the final architecture when no contemporary
+  explanation was preserved.
+
+A retrospective ADR must not present reconstructed motivation as a confirmed
+historical fact.
+
+The metadata field **Rationale provenance** makes this distinction explicit.
+
+## Naming and Numbering
+
+ADR files use a monotonically increasing four-digit identifier followed by a
+short descriptive slug:
 
 ```text
-ADR-0001-short-title.md
-ADR-0002-short-title.md
+ADR-0001-expand-while-scanning.md
+ADR-0002-use-linked-command-pipelines.md
 ```
 
-Each ADR should normally contain:
+Numbers are never reused.
 
-- status;
-- date;
-- context;
-- decision;
-- alternatives considered;
-- consequences;
-- relevant references.
+If an ADR is superseded, its file remains in place and its status is updated.
+A new ADR receives a new number.
 
-## Lifecycle
+The number identifies the record, not the chronological date on which the
+original engineering decision was made.
 
-Accepted ADRs describe decisions that apply to the maintained implementation.
+## Status Model
 
-Historical design notes and decisions that have not yet been verified against
-the final implementation remain under [`../history/`](../history/) until they
-are reviewed.
+The maintained ADR statuses are:
 
-Detailed ADRs will be introduced through the dedicated engineering-decisions
-workstream.
+| Status | Meaning |
+| --- | --- |
+| `Proposed` | A decision is being considered but has not been adopted. |
+| `Accepted` | The decision describes the maintained implementation or an adopted project direction. |
+| `Superseded` | A later ADR replaces this decision. |
+| `Deprecated` | The decision is retained for provenance but should no longer guide new work. |
+
+The initial Minishell ADR set records decisions already present in the
+maintained implementation and will therefore normally use `Accepted`.
+
+## ADR Metadata
+
+Each ADR begins with:
+
+```text
+Status:
+Recorded:
+Decision scope:
+Rationale provenance:
+```
+
+### `Status`
+
+Uses one value from the ADR status model.
+
+### `Recorded`
+
+The date on which the ADR itself was written.
+
+For retrospective ADRs, this is intentionally not presented as the original
+decision date.
+
+### `Decision scope`
+
+Identifies what the record governs.
+
+For the initial ADR set:
+
+```text
+Maintained implementation
+```
+
+### `Rationale provenance`
+
+Describes how strongly the documented rationale is historically supported.
+
+Two forms are used for the initial retrospective records.
+
+When preserved development material explicitly supports the rationale:
+
+```text
+Supported by preserved development material and the final source implementation
+```
+
+When the implementation is certain but the original reasoning was not
+preserved clearly:
+
+```text
+Reconstructed from the final implementation and preserved alternatives
+```
+
+The second form must be accompanied by cautious language in the ADR body.
+
+## ADR Structure
+
+Each record should normally follow this structure:
+
+```markdown
+# ADR-NNNN: Decision title
+
+- **Status:** Accepted
+- **Recorded:** YYYY-MM-DD
+- **Decision scope:** Maintained implementation
+- **Rationale provenance:** ...
+
+## Context
+
+Describe the architectural problem or constraint.
+
+## Decision
+
+State the decision precisely.
+
+## Rationale
+
+Explain why the decision is appropriate.
+
+Distinguish preserved rationale from retrospective interpretation where
+necessary.
+
+## Alternatives Considered
+
+Document alternatives only when they are supported by preserved material or
+are necessary to understand the decision.
+
+Do not invent historical debates.
+
+## Consequences
+
+### Positive
+
+Describe benefits created by the decision.
+
+### Trade-offs
+
+Describe limitations, coupling or future costs introduced by the decision.
+
+## Evidence
+
+Identify implementation or preserved documentation that verifies the record.
+
+## References
+
+Link to relevant maintained architecture and historical material.
+```
+
+Sections may be adjusted when a decision does not meaningfully require every
+heading, but the metadata, context, decision, consequences and evidence should
+remain explicit.
+
+## Alternatives and Historical Claims
+
+The phrase **Alternatives Considered** does not imply that every listed
+alternative was formally debated during original development.
+
+An ADR must distinguish between:
+
+```text
+Preserved project material explicitly considered...
+```
+
+and:
+
+```text
+The architecture could alternatively have...
+```
+
+The second form describes an analytical alternative, not a historical event.
+
+When there is no useful evidence that an alternative mattered, omit it rather
+than manufacturing a comparison.
+
+## Decision Index
+
+The following decisions were selected for the initial ADR set after reviewing
+the final implementation and preserved design material.
+
+| ADR | Decision | Record state |
+| --- | --- | --- |
+| ADR-0001 | Perform variable expansion while quote context is available | Planned |
+| ADR-0002 | Represent pipelines as linked command chains | Planned |
+| ADR-0003 | Execute standalone builtins in the parent shell | Planned |
+| ADR-0004 | Manage pipelines with rolling descriptor state | Planned |
+| ADR-0005 | Prepare pipeline heredocs before launching command children | Planned |
+| ADR-0006 | Maintain an owned mutable environment in shell state | Planned |
+
+`Planned` in this table describes documentation progress, not architectural
+status.
+
+Once recorded, each entry will link to its ADR and show its ADR status.
+
+## Initial Evidence Classification
+
+The initial decisions fall into two provenance groups.
+
+### Preserved rationale available
+
+The following decisions have direct support in preserved development material
+as well as in the final implementation:
+
+- ADR-0001: expansion while quote context is available;
+- ADR-0002: linked command-chain pipeline representation;
+- ADR-0003: standalone builtin execution in the parent process.
+
+### Rationale reconstructed cautiously
+
+The following decisions are unambiguous in the final implementation, but their
+specific original rationale was not preserved as clearly:
+
+- ADR-0004: rolling pipeline descriptor state;
+- ADR-0005: pipeline heredoc preparation before command launch;
+- ADR-0006: owned mutable environment state.
+
+Their ADRs must clearly distinguish implementation evidence from reconstructed
+rationale.
+
+## Relationship to Architecture Documentation
+
+Architecture documentation answers:
+
+> How does the maintained system work?
+
+ADRs answer:
+
+> Why is a significant architectural choice represented this way?
+
+The two documentation layers should link to each other where useful without
+duplicating entire explanations.
+
+Maintained architecture documentation lives under:
+
+[`../architecture/`](../architecture/)
+
+## Relationship to Historical Material
+
+Development-stage design material remains preserved under:
+
+[`../history/design/`](../history/design/)
+
+That material is evidence of project evolution, not automatically the current
+source of truth.
+
+Creating an ADR does not rewrite or retroactively correct historical files.
+
+If historical intent differs from the final implementation, the ADR should
+identify that distinction explicitly when it is relevant to understanding the
+decision.
+
+## Maintenance Rules
+
+When adding or updating ADRs:
+
+- keep one durable decision per record;
+- never reuse ADR numbers;
+- preserve superseded ADRs;
+- distinguish implementation evidence from inferred rationale;
+- avoid unsupported claims about original developer intent;
+- link to maintained architecture rather than duplicating it wholesale;
+- preserve historical documentation unchanged;
+- update the decision index when ADR status changes;
+- keep ADR changes separate from unrelated source modifications.
+
+A source change that intentionally reverses an accepted architectural decision
+should update or supersede the corresponding ADR as part of the same
+engineering change whenever practical.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -238,7 +238,7 @@ the final implementation and preserved design material.
 | [ADR-0002](ADR-0002-use-linked-command-pipelines.md) | Represent pipelines as linked command chains | Accepted |
 | [ADR-0003](ADR-0003-run-standalone-builtins-in-parent.md) | Execute standalone builtins in the parent shell | Accepted |
 | [ADR-0004](ADR-0004-use-rolling-pipeline-state.md) | Manage pipelines with rolling descriptor state | Accepted |
-| ADR-0005 | Prepare pipeline heredocs before launching command children | Planned |
+| [ADR-0005](ADR-0005-prepare-pipeline-heredocs-before-launch.md) | Prepare pipeline heredocs before launching command children | Accepted |
 | ADR-0006 | Maintain an owned mutable environment in shell state | Planned |
 
 `Planned` in this table describes documentation progress, not architectural

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -237,7 +237,7 @@ the final implementation and preserved design material.
 | [ADR-0001](ADR-0001-expand-while-scanning.md) | Perform variable expansion while quote context is available | Accepted |
 | [ADR-0002](ADR-0002-use-linked-command-pipelines.md) | Represent pipelines as linked command chains | Accepted |
 | [ADR-0003](ADR-0003-run-standalone-builtins-in-parent.md) | Execute standalone builtins in the parent shell | Accepted |
-| ADR-0004 | Manage pipelines with rolling descriptor state | Planned |
+| [ADR-0004](ADR-0004-use-rolling-pipeline-state.md) | Manage pipelines with rolling descriptor state | Accepted |
 | ADR-0005 | Prepare pipeline heredocs before launching command children | Planned |
 | ADR-0006 | Maintain an owned mutable environment in shell state | Planned |
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -232,7 +232,7 @@ than manufacturing a comparison.
 The following decisions were selected for the initial ADR set after reviewing
 the final implementation and preserved design material.
 
-| ADR | Decision | Record state |
+| ADR | Decision | Status |
 | --- | --- | --- |
 | [ADR-0001](ADR-0001-expand-while-scanning.md) | Perform variable expansion while quote context is available | Accepted |
 | [ADR-0002](ADR-0002-use-linked-command-pipelines.md) | Represent pipelines as linked command chains | Accepted |
@@ -240,11 +240,6 @@ the final implementation and preserved design material.
 | [ADR-0004](ADR-0004-use-rolling-pipeline-state.md) | Manage pipelines with rolling descriptor state | Accepted |
 | [ADR-0005](ADR-0005-prepare-pipeline-heredocs-before-launch.md) | Prepare pipeline heredocs before launching command children | Accepted |
 | [ADR-0006](ADR-0006-own-mutable-shell-environment.md) | Maintain an owned mutable environment in shell state | Accepted |
-
-`Planned` in this table describes documentation progress, not architectural
-status.
-
-Once recorded, each entry will link to its ADR and show its ADR status.
 
 ## Initial Evidence Classification
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -235,7 +235,7 @@ the final implementation and preserved design material.
 | ADR | Decision | Record state |
 | --- | --- | --- |
 | [ADR-0001](ADR-0001-expand-while-scanning.md) | Perform variable expansion while quote context is available | Accepted |
-| ADR-0002 | Represent pipelines as linked command chains | Planned |
+| [ADR-0002](ADR-0002-use-linked-command-pipelines.md) | Represent pipelines as linked command chains | Accepted |
 | ADR-0003 | Execute standalone builtins in the parent shell | Planned |
 | ADR-0004 | Manage pipelines with rolling descriptor state | Planned |
 | ADR-0005 | Prepare pipeline heredocs before launching command children | Planned |


### PR DESCRIPTION
## Summary

Establishes the repository's Architecture Decision Record practice and records
the key engineering decisions that define the maintained Minishell
implementation.

The ADR set distinguishes source-verified implementation facts from historical
rationale and explicitly labels rationale that had to be reconstructed from the
final implementation and preserved alternatives.

## Decisions recorded

- ADR-0001: perform variable expansion while quote context is available
- ADR-0002: represent pipelines as linked command chains
- ADR-0003: execute standalone builtins in the parent shell
- ADR-0004: manage pipelines with rolling descriptor state
- ADR-0005: prepare pipeline heredocs before launching command children
- ADR-0006: maintain an owned mutable environment in shell state

## Documentation model

The decisions documentation now defines:

- ADR scope and inclusion criteria
- numbering and naming conventions
- Accepted, Proposed, Superseded and Deprecated states
- rationale provenance requirements
- retrospective-record rules
- evidence and reference expectations
- the relationship between source code, architecture docs, ADRs and historical material

## Validation

- six ADR files present and indexed
- all six ADRs marked Accepted
- three ADRs backed by preserved rationale
- three ADRs explicitly marked as retrospectively reconstructed
- local documentation links validated
- Markdown fences validated
- stale placeholder wording removed
- `git diff --check` passes
- changes restricted to `docs/decisions/`
- no production source behaviour changed

Closes #33
