### PR TITLE
docs(development): establish contribution and Git workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,198 @@
+# Contributing
+
+This repository preserves a completed 42 Minishell project while continuing to
+evolve as a professional software-engineering portfolio.
+
+Contributions and maintenance changes should preserve that distinction.
+
+## Start with an Issue
+
+Meaningful repository changes should begin with a GitHub issue.
+
+The issue should describe:
+
+- the problem or improvement;
+- the intended scope;
+- relevant constraints;
+- acceptance criteria where useful.
+
+This keeps later branches, commits and pull requests connected to a clear unit
+of work.
+
+Small corrections that do not justify separate tracking may be handled
+directly in a focused maintenance branch.
+
+## Development Workflow
+
+The maintained repository uses short-lived branches and pull requests rather
+than direct development on `main`.
+
+The normal lifecycle is:
+
+```text
+issue
+  |
+  v
+short-lived branch
+  |
+  v
+focused commits
+  |
+  v
+pull request
+  |
+  v
+validation and review
+  |
+  v
+squash merge
+  |
+  v
+branch cleanup
+```
+
+Detailed branch, commit, validation, pull-request and merge conventions are
+documented in:
+
+[`docs/development/git-workflow.md`](docs/development/git-workflow.md)
+
+## Branches
+
+Create maintenance branches from an up-to-date `main`.
+
+Use:
+
+```text
+<type>/<issue-number>-<short-description>
+```
+
+Common branch types include:
+
+- `feat/` for new functionality;
+- `fix/` for bug fixes;
+- `docs/` for documentation;
+- `test/` for testing work;
+- `refactor/` for behaviour-preserving restructuring;
+- `ci/` for automation and CI changes;
+- `chore/` for repository maintenance.
+
+For example:
+
+```text
+docs/35-contribution-git-workflow
+fix/42-heredoc-interrupt-cleanup
+test/56-signal-regressions
+```
+
+The issue number provides repository-level traceability without depending on
+the Jira conventions used during the original project.
+
+## Commits
+
+Prefer small, coherent commits that describe one understandable change.
+
+Current portfolio-maintenance commits use a lightweight conventional-style
+format:
+
+```text
+<type>(<scope>): <summary>
+```
+
+For example:
+
+```text
+docs(repo): standardize metadata and README
+docs(architecture): document current architecture and runtime flow
+docs(decisions): establish ADR convention and index
+```
+
+A scope may be omitted when it does not add useful information.
+
+Working commits on a feature branch do not need to correspond one-to-one with
+the final history of `main`.
+
+Pull requests are squash-merged, so several focused branch commits normally
+become one durable commit on `main`.
+
+## Pull Requests
+
+Open pull requests against `main`.
+
+A pull request should:
+
+- have one clear purpose;
+- remain within the scope of its issue;
+- explain what changed and why;
+- describe relevant validation;
+- avoid unrelated cleanup;
+- resolve review conversations before merge.
+
+The repository runs a CI build workflow for pull requests. Contributors should
+ensure that applicable validation passes before merge.
+
+The repository's GitHub configuration and pull-request templates may evolve
+through separate modernization workstreams. The detailed development guide
+documents the maintained workflow independently of historical template text.
+
+## Merge Policy
+
+`main` is the maintained stable branch.
+
+Changes to `main` are integrated through pull requests and squash merge.
+
+This allows a working branch to contain several useful intermediate commits
+while keeping the long-lived branch concise:
+
+```text
+feature branch
+
+commit A
+commit B
+commit C
+    |
+    v
+pull request
+    |
+    v
+squash merge
+    |
+    v
+main
+
+one durable commit
+```
+
+After merge, delete the short-lived branch and synchronize the local `main`
+with the remote repository.
+
+## Historical Project Work
+
+The original Minishell project was developed collaboratively during the
+42 Porto Common Core.
+
+Its Git history and contributor attribution are intentionally preserved.
+
+Historical Jira conventions, team agreements and development procedures remain
+available under:
+
+[`docs/history/team-workflow/`](docs/history/team-workflow/)
+
+They provide project provenance but are not automatically current contribution
+policy.
+
+Portfolio maintenance should not rewrite historical commits, remove original
+authorship or present later work as part of the original 42 delivery.
+
+## Documentation
+
+The maintained documentation entry point is:
+
+[`docs/`](docs/)
+
+Current contribution and repository-maintenance documentation lives under:
+
+[`docs/development/`](docs/development/)
+
+The source code remains authoritative for implemented behaviour, while current
+documentation describes the maintained repository and historical material
+preserves project provenance.

--- a/README.md
+++ b/README.md
@@ -492,6 +492,19 @@ intended design rather than every detail of the final implementation. They are
 being reconciled with the final code as part of the repository modernization
 initiative.
 
+## Contributing
+
+Current contribution and repository-maintenance guidance is available in
+[`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+The detailed issue, branch, commit, validation, pull-request, squash-merge and
+cleanup workflow is documented in
+[`docs/development/git-workflow.md`](docs/development/git-workflow.md).
+
+The maintained workflow uses GitHub Issues for current work tracking while
+preserving the original Jira-based team workflow separately as project
+history.
+
 ## Project History
 
 This project was originally developed collaboratively by a two-person team

--- a/docs/README.md
+++ b/docs/README.md
@@ -105,17 +105,22 @@ Documentation in this repository should be:
 Documentation structure should grow when information needs a durable home, not
 to imitate organizational complexity that the project does not require.
 
-## Planned Documentation Work
+## Documentation Evolution
 
-The repository modernization initiative will develop the active domains
-incrementally, including:
+The repository modernization initiative develops the active documentation
+domains incrementally.
+
+The maintained repository now includes:
 
 - current architecture and runtime-flow documentation;
 - engineering decision records;
-- contribution and Git workflow documentation;
+- contribution and Git workflow documentation.
+
+Further work is tracked separately for areas including:
+
 - maintained testing and validation strategy;
 - automated quality and CI documentation;
 - API documentation where it adds value.
 
-Until those workstreams are completed, historical material remains available
-under [`history/`](history/) as evidence and context.
+Historical material remains available under [`history/`](history/) as evidence
+and context while current documentation evolves independently.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -1,23 +1,115 @@
 # Development
 
-This directory documents the current development workflow for maintaining and
-extending the repository.
+This directory documents the current contribution, maintenance and repository
+workflow for Minishell.
 
-## Scope
+It describes how the repository is maintained after the original 42 project
+baseline and should not be confused with the historical two-person team
+workflow.
 
-Development documentation may cover:
+## Start Here
 
-- contribution workflow;
-- branch and commit conventions;
+For contributors and maintainers beginning from the repository root:
+
+- [`../../CONTRIBUTING.md`](../../CONTRIBUTING.md) provides the public
+  contribution entry point;
+- [`git-workflow.md`](git-workflow.md) documents the detailed Git and GitHub
+  lifecycle.
+
+## Current Workflow
+
+The maintained development model is:
+
+```text
+GitHub issue
+      |
+      v
+short-lived branch
+      |
+      v
+focused commits
+      |
+      v
+local validation
+      |
+      v
+pull request
+      |
+      v
+CI + review
+      |
+      v
+squash merge
+      |
+      v
+branch cleanup
+```
+
+The detailed workflow covers:
+
+- GitHub Issues as the current work-tracking mechanism;
+- branch naming and issue traceability;
+- commit-message conventions;
+- local validation;
 - pull-request expectations;
-- repository governance;
-- local development practices;
-- code-review expectations;
-- release and maintenance procedures.
+- CI and review;
+- `CODEOWNERS`;
+- protected `main` behaviour;
+- squash merge;
+- post-merge branch cleanup;
+- synchronization of the local repository after merge.
 
-Historical team agreements, Jira conventions and the workflow used during the
-original two-person 42 project are preserved under
-[`../history/team-workflow/`](../history/team-workflow/).
+See:
 
-The current repository workflow will be documented through its dedicated
-modernization workstream.
+[`git-workflow.md`](git-workflow.md)
+
+## Repository Governance
+
+The maintained repository uses a protected `main` branch and short-lived
+working branches.
+
+Current governance and workflow policy are documented from the repository's
+maintained configuration rather than inferred from historical project
+agreements.
+
+Where GitHub technically enforces a rule, the workflow identifies it as
+repository-enforced policy.
+
+Where a practice is maintained by convention rather than enforcement, it is
+documented separately as maintained workflow.
+
+This distinction is important for rules such as review expectations,
+`CODEOWNERS` behaviour and approval requirements.
+
+## Historical Workflow
+
+The original Minishell project was developed by a two-person team using
+additional Jira-based conventions and collaboration agreements.
+
+Those records are preserved under:
+
+[`../history/team-workflow/`](../history/team-workflow/)
+
+Historical material includes:
+
+- Jira-key policies;
+- original branch and commit conventions;
+- working agreements;
+- definitions of ready and done;
+- Git command references;
+- original repository-governance notes.
+
+These documents preserve project provenance.
+
+They are not automatically authoritative for current portfolio maintenance.
+
+## Related Documentation
+
+- [`../README.md`](../README.md) defines the repository-wide documentation
+  model.
+- [`../architecture/`](../architecture/) documents the maintained system
+  architecture.
+- [`../decisions/`](../decisions/) records significant engineering decisions.
+- [`../testing/`](../testing/) is the maintained testing and validation domain.
+- [`../history/`](../history/) preserves original and superseded project
+  material.

--- a/docs/development/git-workflow.md
+++ b/docs/development/git-workflow.md
@@ -1,0 +1,7 @@
+# Git Workflow
+
+This document defines the maintained issue, branch, commit, pull-request,
+validation, merge and cleanup workflow for the repository.
+
+Detailed workflow guidance is being completed as part of
+[issue #35](https://github.com/LuisQAlmeida/42Minishell/issues/35).

--- a/docs/development/git-workflow.md
+++ b/docs/development/git-workflow.md
@@ -1,7 +1,670 @@
 # Git Workflow
 
-This document defines the maintained issue, branch, commit, pull-request,
-validation, merge and cleanup workflow for the repository.
+This document defines the maintained Git and GitHub workflow for repository
+maintenance and future development.
 
-Detailed workflow guidance is being completed as part of
-[issue #35](https://github.com/LuisQAlmeida/42Minishell/issues/35).
+It describes the current portfolio-maintenance process rather than the workflow
+used during the original two-person 42 project.
+
+For the public contribution entry point, see
+[`../../CONTRIBUTING.md`](../../CONTRIBUTING.md).
+
+## Workflow at a Glance
+
+The normal lifecycle for meaningful work is:
+
+```text
+identify work
+      |
+      v
+GitHub issue
+      |
+      v
+synchronize main
+      |
+      v
+short-lived branch
+      |
+      v
+focused commits
+      |
+      v
+local validation
+      |
+      v
+push branch
+      |
+      v
+pull request into main
+      |
+      +--> CI build
+      +--> review / discussion
+      +--> resolve conversations
+      |
+      v
+squash merge
+      |
+      v
+delete branch
+      |
+      v
+synchronize local main
+```
+
+The workflow is intentionally lightweight.
+
+It provides traceability and a clean long-lived history without reproducing the
+heavier Jira-based process used during the original project.
+
+## Policy Levels
+
+Not every workflow practice has the same enforcement mechanism.
+
+This documentation distinguishes three categories.
+
+### Repository-enforced policy
+
+These behaviours are enforced by the current GitHub repository configuration:
+
+- changes to protected `main` go through a pull request;
+- `main` uses linear history;
+- pull-request conversations must be resolved before merge;
+- force pushes to `main` are blocked;
+- deletion of `main` is restricted;
+- squash merge is the enabled merge strategy for maintained pull requests.
+
+The current protection configuration does not require an approval count greater
+than zero.
+
+### Maintained workflow
+
+These practices are part of the current repository-maintenance process even
+when GitHub does not technically enforce every step:
+
+- begin meaningful work from a GitHub issue;
+- branch from an up-to-date `main`;
+- include the issue number in the branch name;
+- create focused, understandable commits;
+- validate the change before opening or merging a pull request;
+- allow the pull-request CI build to complete successfully;
+- review the final diff before merge;
+- delete short-lived branches after merge;
+- synchronize the local `main` after the merge.
+
+These conventions should be treated as the normal development contract for the
+repository.
+
+### Historical workflow
+
+The original project used additional collaboration conventions including:
+
+- Jira issue keys such as `MSH-21`;
+- Jira-key branch and commit naming;
+- two-person working agreements;
+- stronger teammate-approval expectations;
+- project-specific definitions of ready and done.
+
+Those records remain under
+[`../history/team-workflow/`](../history/team-workflow/).
+
+They preserve project provenance but are not current maintenance policy unless
+a rule is explicitly re-established in maintained documentation.
+
+## 1. Start from an Issue
+
+Meaningful changes should normally begin with a GitHub issue.
+
+An issue gives the work a durable identity before implementation begins.
+
+Useful issue content includes:
+
+- context;
+- objective;
+- intended scope;
+- explicit exclusions;
+- acceptance criteria;
+- dependencies or parent initiatives when relevant.
+
+The issue becomes the traceability anchor for the branch and pull request.
+
+For example:
+
+```text
+Issue #35
+Establish contribution and Git workflow
+```
+
+may be implemented on:
+
+```text
+docs/35-contribution-git-workflow
+```
+
+Small corrections that do not justify separate tracking may still use a
+focused maintenance branch without a dedicated issue.
+
+## 2. Synchronize `main`
+
+Before creating a branch, synchronize the local stable branch with the remote:
+
+```bash
+git switch main
+git pull --ff-only origin main
+git fetch origin --prune
+git status
+```
+
+`git pull --ff-only` is preferred here because synchronization should not create
+an accidental merge commit on `main`.
+
+The expected state is:
+
+```text
+On branch main
+Your branch is up to date with 'origin/main'.
+
+nothing to commit, working tree clean
+```
+
+Do not start unrelated work from a dirty working tree.
+
+## 3. Create a Short-Lived Branch
+
+Use:
+
+```text
+<type>/<issue-number>-<short-description>
+```
+
+Common branch types are:
+
+| Type | Purpose |
+| --- | --- |
+| `feat/` | New functionality |
+| `fix/` | Bug fixes |
+| `docs/` | Documentation |
+| `test/` | Testing or validation work |
+| `refactor/` | Behaviour-preserving code restructuring |
+| `ci/` | Continuous-integration or automation work |
+| `chore/` | Repository maintenance |
+
+Examples:
+
+```text
+docs/35-contribution-git-workflow
+fix/42-heredoc-interrupt-cleanup
+test/56-signal-regressions
+ci/60-static-analysis
+```
+
+Create and publish the branch with:
+
+```bash
+git switch -c docs/35-contribution-git-workflow
+git push -u origin docs/35-contribution-git-workflow
+```
+
+The GitHub issue number replaces the Jira-key dependency used by the historical
+workflow.
+
+Keep branch names short enough to scan quickly while still making their purpose
+clear.
+
+## 4. Keep the Change Focused
+
+A branch should represent one coherent piece of work.
+
+Avoid mixing unrelated changes such as:
+
+```text
+documentation rewrite
++
+unrelated source refactor
++
+formatting cleanup
++
+CI changes
+```
+
+unless the issue explicitly requires all of them.
+
+A focused branch makes the pull request easier to understand, validate and
+review.
+
+If unrelated work is discovered, prefer recording it as a separate issue
+instead of silently expanding the active branch.
+
+## 5. Make Focused Commits
+
+Working commits should describe understandable increments of the change.
+
+The maintained repository uses a lightweight conventional-style format:
+
+```text
+<type>(<scope>): <summary>
+```
+
+Examples:
+
+```text
+docs(repo): standardize metadata and README
+docs(architecture): document current architecture and runtime flow
+docs(decisions): establish ADR convention and index
+fix(exec): preserve pipeline exit status
+test(signals): cover heredoc interruption
+```
+
+A scope may be omitted when it adds no useful information:
+
+```text
+docs: fix broken development link
+```
+
+Commit messages should:
+
+- use an imperative or concise action-oriented summary;
+- identify the kind of change;
+- avoid vague messages such as `update`, `changes` or `fix stuff`;
+- describe the commit itself rather than the entire issue.
+
+The GitHub issue number does not need to be repeated in every commit because the
+branch and pull request provide issue-level traceability.
+
+### Working history versus `main` history
+
+Several focused commits may exist on the feature branch:
+
+```text
+branch
+
+commit A
+commit B
+commit C
+commit D
+```
+
+That is useful working history.
+
+The pull request is later squash-merged:
+
+```text
+commit A
+commit B
+commit C
+commit D
+    |
+    v
+pull request
+    |
+    v
+squash
+    |
+    v
+one commit on main
+```
+
+This allows detailed iteration during development while keeping `main`
+portfolio-readable.
+
+## 6. Validate Before the Pull Request
+
+Validation should match the kind of change being made.
+
+At minimum, inspect the working tree and patch:
+
+```bash
+git status
+git diff --check
+git diff
+```
+
+For staged work:
+
+```bash
+git diff --cached --check
+git diff --cached
+```
+
+For source changes, applicable validation may include:
+
+```bash
+make
+```
+
+and relevant manual or regression tests.
+
+Depending on the subsystem, additional checks may include:
+
+- Norminette where applicable to 42-style source files;
+- Valgrind for memory-sensitive paths;
+- file-descriptor checks for pipes and redirections;
+- exit-status validation;
+- signal-behaviour validation;
+- documentation link or formatting checks.
+
+Validation requirements should be proportional to the change rather than
+performed mechanically when they are irrelevant.
+
+Documentation-only changes should not pretend to have exercised runtime
+behaviour they did not modify.
+
+## 7. Push the Branch
+
+After committing:
+
+```bash
+git push
+```
+
+For the first push of a branch without an upstream:
+
+```bash
+git push -u origin <branch-name>
+```
+
+Confirm afterward:
+
+```bash
+git status
+```
+
+The local branch should report that it is up to date with its remote tracking
+branch.
+
+## 8. Open a Pull Request
+
+Open the pull request against:
+
+```text
+base: main
+```
+
+The pull request should clearly explain:
+
+- what changed;
+- why the change exists;
+- what was deliberately kept out of scope;
+- how the work was validated;
+- which issue it resolves.
+
+When the pull request should automatically close its GitHub issue after merge,
+use a supported closing reference such as:
+
+```text
+Closes #35
+```
+
+Keep the pull request focused on one primary unit of work.
+
+### Current pull-request template
+
+The repository currently contains
+[`.github/PULL_REQUEST_TEMPLATE.md`](../../.github/PULL_REQUEST_TEMPLATE.md).
+
+That template originated from the historical Jira-based development workflow
+and still contains project-era terminology.
+
+Its modernization belongs to the dedicated GitHub template workstream.
+
+Until that work is completed, maintained workflow documentation takes
+precedence over historical Jira-specific wording in the template.
+
+## 9. CI and Validation on GitHub
+
+The repository currently defines:
+
+[`../../.github/workflows/ci.yml`](../../.github/workflows/ci.yml)
+
+The workflow runs:
+
+- for pull requests;
+- for pushes to `main`.
+
+Its current job installs the readline development dependency and builds the
+project when a `Makefile` exists.
+
+A successful build is useful evidence that the pull request still compiles.
+
+The current CI workflow should not be described as a complete quality gate.
+
+Automated tests, static analysis and broader quality checks belong to separate
+modernization workstreams.
+
+Before merge, confirm that the available checks have completed successfully.
+
+## 10. Review and `CODEOWNERS`
+
+The repository currently defines:
+
+[`../../.github/CODEOWNERS`](../../.github/CODEOWNERS)
+
+with repository-wide ownership entries for the original collaborators.
+
+This preserves ownership context and can cause GitHub to request appropriate
+reviewers.
+
+`CODEOWNERS` should not be confused with the current approval requirement.
+
+The repository currently permits pull-request merge without requiring a
+positive approval count, although unresolved review conversations must be
+resolved before merge.
+
+Review remains useful even when an approval is not technically required.
+
+Relevant review may examine:
+
+- scope;
+- correctness;
+- unintended behaviour changes;
+- resource ownership;
+- documentation accuracy;
+- test evidence;
+- historical attribution;
+- consistency with accepted ADRs.
+
+## 11. Keep the Branch Current When Necessary
+
+A branch does not need continual synchronization with `main` merely for visual
+tidiness.
+
+Update it when:
+
+- `main` has changed in a way relevant to the active work;
+- GitHub reports a conflict;
+- validation against the newer base is necessary;
+- repository policy requires an updated branch before merge.
+
+Before integrating changes from `main`, first fetch the current remote state:
+
+```bash
+git fetch origin
+```
+
+Because the maintained repository values linear long-lived history, avoid
+introducing unnecessary merge commits purely to refresh a feature branch.
+
+The exact conflict-resolution method should be chosen deliberately based on
+whether the branch is private or shared and whether rewriting its history is
+safe.
+
+Do not force-push shared history casually.
+
+## 12. Review the Final Pull Request Diff
+
+Before merging, inspect the pull request as a whole rather than relying only on
+individual working commits.
+
+Confirm:
+
+- the changed files match the issue scope;
+- no temporary or generated files were included;
+- no unrelated source changes slipped into documentation work;
+- documentation links remain valid;
+- validation results match the claims in the pull request;
+- review conversations are resolved;
+- the final commit message produced by squash merge will be meaningful on
+  `main`.
+
+A useful local scope check is:
+
+```bash
+git fetch origin
+git diff --name-status origin/main...HEAD
+git diff --check origin/main...HEAD
+```
+
+## 13. Squash Merge
+
+The maintained repository uses squash merge for pull requests.
+
+The branch may contain:
+
+```text
+commit A
+commit B
+commit C
+```
+
+but `main` receives one durable commit representing the completed unit of work.
+
+The squash commit should summarize the completed change rather than merely copy
+an intermediate branch commit.
+
+For example:
+
+```text
+docs(development): establish contribution and Git workflow (#NN)
+```
+
+This keeps the long-lived history concise while the pull request preserves the
+detailed development conversation and branch-level work.
+
+## 14. Delete the Merged Branch
+
+After a successful merge, the short-lived remote branch should be removed.
+
+The repository is configured to clean up merged head branches automatically
+through GitHub.
+
+Synchronize locally:
+
+```bash
+git switch main
+git pull --ff-only origin main
+git fetch origin --prune
+```
+
+Then delete the local feature branch.
+
+For a normal merged branch:
+
+```bash
+git branch -d <branch-name>
+```
+
+After a squash merge, Git may not recognize the feature branch tip as an
+ancestor of `main` because the branch commits were replaced by a new squash
+commit.
+
+Once the merge has been independently confirmed, local cleanup may therefore
+require:
+
+```bash
+git branch -D <branch-name>
+```
+
+Use `-D` only after confirming that the pull request was successfully merged
+and the branch contains no work that still needs to be preserved.
+
+## 15. Confirm the New Baseline
+
+After cleanup:
+
+```bash
+git status
+git log -5 --oneline
+git branch -vv
+```
+
+The expected state is:
+
+```text
+main
+  |
+  `--> synchronized with origin/main
+
+working tree
+  |
+  `--> clean
+
+feature branch
+  |
+  `--> removed
+```
+
+The squash commit on `main` becomes the new baseline for the next workstream.
+
+## Repository Governance Summary
+
+The current maintenance model can be summarized as:
+
+| Concern | Current model |
+| --- | --- |
+| Stable branch | `main` |
+| Work tracking | GitHub Issues |
+| Working branches | Short-lived, issue-linked branches |
+| Direct development on `main` | Avoided through protected PR workflow |
+| Branch naming | `<type>/<issue-number>-<short-description>` |
+| Working commits | Focused conventional-style messages |
+| Pull requests | Target `main` |
+| Automated check | CI build |
+| Required approval count | 0 |
+| Review conversations | Must be resolved before merge |
+| Long-lived history | Linear |
+| Merge strategy | Squash |
+| Force pushes to `main` | Blocked |
+| Deletion of `main` | Restricted |
+| Merged remote branches | Automatically cleaned up |
+| Historical Jira workflow | Preserved, not current policy |
+
+## Historical Provenance
+
+The original two-person workflow is preserved under:
+
+[`../history/team-workflow/`](../history/team-workflow/)
+
+That material includes historical:
+
+- Jira conventions;
+- branch and commit policies;
+- Git commands;
+- definitions of ready and done;
+- working agreements;
+- GitHub repository setup notes.
+
+It should be consulted when studying the original project process, not used
+silently as the current repository workflow.
+
+In particular, current maintenance must not imply that:
+
+- Jira remains the active work tracker;
+- every branch requires an `MSH-*` key;
+- every commit requires a Jira key;
+- two approvals are currently required;
+- the original collaborators are still operating under the historical team
+  agreement.
+
+The repository preserves the historical record rather than rewriting it to
+match later portfolio maintenance.
+
+## Related Documentation
+
+- [`../../CONTRIBUTING.md`](../../CONTRIBUTING.md) provides the public
+  contribution entry point.
+- [`README.md`](README.md) indexes current development documentation.
+- [`../README.md`](../README.md) defines the repository-wide documentation
+  model.
+- [`../decisions/README.md`](../decisions/README.md) documents engineering
+  decision records.
+- [`../history/team-workflow/`](../history/team-workflow/) preserves the
+  original project workflow.


### PR DESCRIPTION
## Summary

Establishes the maintained contribution and Git workflow for the repository.

The new documentation defines how current portfolio maintenance moves from a
GitHub issue through a short-lived branch, focused commits, validation, pull
request, review, squash merge and post-merge cleanup.

It also explicitly separates current repository policy from the Jira-based
workflow used during the original two-person 42 project.

## What changed

- added a root `CONTRIBUTING.md` as the public contribution entry point;
- added `docs/development/git-workflow.md` with the detailed operational
  workflow;
- expanded `docs/development/README.md` into the maintained development
  documentation index;
- added contribution navigation to the root `README.md`;
- updated `docs/README.md` to reflect the completed contribution-workflow
  documentation.

## Workflow documented

The maintained workflow now covers:

- GitHub Issues as the current work-tracking mechanism;
- issue-linked short-lived branch naming;
- lightweight conventional-style commit messages;
- focused branch and commit scope;
- local validation before pull requests;
- pull-request expectations;
- CI build behaviour;
- `CODEOWNERS` and review semantics;
- protected `main` behaviour;
- squash merge;
- remote and local branch cleanup;
- synchronization of `main` after merge.

## Current vs historical workflow

The documentation distinguishes:

- repository-enforced GitHub policy;
- maintained workflow conventions;
- historical two-person 42 development practices.

Historical Jira keys, original team agreements and previous review requirements
remain preserved under `docs/history/team-workflow/` for provenance, but are
not presented as current repository policy.

The existing Jira-oriented pull-request template is intentionally left
unchanged because template modernization belongs to its own workstream.

## Validation

- final issue acceptance audit passes;
- 37 local documentation links validated;
- Markdown fences validated;
- `git diff --check` passes;
- no source files changed;
- no `.github/` files changed;
- no CI or template behaviour changed;
- branch contains only contribution and documentation changes.

Closes #35