### PR TITLE
fix(github): correct issue form schema

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,8 +1,5 @@
 name: Bug report
 description: Report incorrect or unexpected behaviour in the maintained repository.
-title: ""
-labels: []
-assignees: []
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,8 +1,5 @@
 name: Enhancement
 description: Propose a new capability or deliberate improvement.
-title: ""
-labels: []
-assignees: []
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance.yml
@@ -1,8 +1,5 @@
 name: Maintenance
 description: Track documentation, testing, refactoring, CI or repository-maintenance work.
-title: ""
-labels: []
-assignees: []
 
 body:
   - type: markdown


### PR DESCRIPTION
## Linked issue

Closes #37

## Summary

Corrects the maintained GitHub Issue Forms so GitHub can recognize them as
valid issue templates.

## Why

After the template modernization was merged, navigating to
`/issues/new/choose` redirected directly to the blank issue editor instead of
showing the configured Issue Forms.

The forms contained optional top-level fields with empty values, including an
empty `title` string.

## Scope

### Included

- removed empty `title` values from all three Issue Forms;
- removed unused empty `labels` and `assignees` declarations;
- preserved the existing Issue Form structure and content.

### Out of scope

- changing Issue Form fields;
- adding automatic labels;
- changing the pull-request template;
- changing CI or repository governance;
- source-code changes.

## Validation

- [x] `git diff --check` passes
- [x] YAML parsing passes
- [x] GitHub Issue Form structural audit passes
- [x] Diff is limited to three Issue Form files
- [x] No source or CI changes are included

### Validation details

The correction removes nine optional top-level declarations across the three
Issue Forms without reformatting or changing their field definitions.

Functional recognition by GitHub will be verified again after merge by opening
`/issues/new/choose`.

## Review notes

This is a post-merge correction to the template work completed in #37.

## Checklist

- [x] The pull request has one clear purpose.
- [x] Changes remain within the linked issue scope.
- [x] Unrelated cleanup has not been included.
- [x] Historical project material remains untouched.
- [x] No generated or temporary files are included.
- [x] The final diff has been reviewed.