### PR TITLE
docs(testing): establish testing structure and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,29 +423,35 @@ different signal policies.
 This avoids treating asynchronous input as if every process were in the same
 execution state.
 
-## Testing
+## Testing and Validation
 
-The repository preserves the original mandatory manual test matrix used during
-project validation, covering:
-
-- prompt and history behaviour;
-- quoting;
-- expansion;
-- built-ins;
-- external command execution;
-- redirections;
-- heredocs;
-- multi-stage pipelines;
-- signals;
-- error handling and exit statuses.
+The maintained testing documentation defines how the current repository is
+validated and distinguishes current checks from historical project evidence.
 
 See:
 
-[`docs/history/validation/mandatory-test-matrix.md`](docs/history/validation/mandatory-test-matrix.md)
+- [`docs/testing/validation-strategy.md`](docs/testing/validation-strategy.md)
+  for validation layers, expectations by change type, CI boundaries and known
+  testing gaps;
+- [`docs/testing/manual-validation.md`](docs/testing/manual-validation.md)
+  for reproducible manual checks covering shell behaviour, signals, memory,
+  file descriptors and repository changes.
 
-The repository currently runs a CI build check on pull requests. Additional
-automated testing, static analysis and quality gates are planned as part of the
-repository modernization work.
+The current GitHub Actions workflow provides automated build validation on pull
+requests and pushes to `main`. It currently runs `make`; it does not provide an
+automated behavioural regression suite, resource checks, static analysis or
+coverage reporting.
+
+Original 42 evaluation preparation and project-era validation evidence remain
+preserved under
+[`docs/history/validation/`](docs/history/validation/), including the original
+mandatory manual test matrix.
+
+Historical PASS results are evidence of the original project validation, not
+claims that the current baseline is automatically revalidated.
+
+Automated regression testing, static analysis and broader CI quality gates
+remain future modernization work.
 
 ## Current Scope and Limitations
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ artifacts.
 | [Architecture](architecture/) | Current system structure, runtime flows and subsystem relationships | Active documentation domain |
 | [Engineering Decisions](decisions/) | Significant technical decisions and Architecture Decision Records | Active documentation domain |
 | [Development](development/) | Current contribution, maintenance and repository workflow | Active documentation domain |
-| [Testing and Validation](testing/) | Current verification strategy and maintained test documentation | Active documentation domain |
+| [Testing and Validation](testing/) | Maintained validation strategy and reproducible manual validation guidance | Active documentation domain |
 | [Project History](history/) | Original requirements, design history, planning, validation evidence and previous team workflow | Historical |
 
 The active documentation domains currently establish the repository
@@ -29,7 +29,7 @@ docs/
 ├── architecture/   current system design
 ├── decisions/      accepted engineering decisions
 ├── development/    current development workflow
-├── testing/        current verification strategy
+├── testing/        maintained testing and validation
 └── history/        original and superseded project artifacts
 ```
 
@@ -114,12 +114,13 @@ The maintained repository now includes:
 
 - current architecture and runtime-flow documentation;
 - engineering decision records;
-- contribution and Git workflow documentation.
+- contribution and Git workflow documentation;
+- maintained testing strategy and manual validation guidance.
 
 Further work is tracked separately for areas including:
 
-- maintained testing and validation strategy;
-- automated quality and CI documentation;
+- automated regression testing and broader CI quality gates;
+- static-analysis automation;
 - API documentation where it adds value.
 
 Historical material remains available under [`history/`](history/) as evidence

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -35,10 +35,10 @@ The current validation model is documented in:
 
 - [`validation-strategy.md`](validation-strategy.md), which defines validation
   layers, expectations by change type, evidence standards, CI boundaries and
-  known testing gaps.
-
-A maintained manual-validation guide is developed separately within this
-testing workstream.
+  known testing gaps;
+- [`manual-validation.md`](manual-validation.md), which provides reproducible
+  operational checks for build, behaviour, signals, memory, file descriptors
+  and repository changes.
 
 ## Historical Validation Evidence
 

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -1,25 +1,93 @@
 # Testing and Validation
 
-This directory contains the current verification strategy and maintained test
-documentation for the repository.
+This directory defines the maintained testing and validation model for the
+repository.
 
-## Scope
+It describes what can be verified today, which checks are manual, what the
+current CI workflow actually guarantees and where historical validation
+evidence is preserved.
 
-Testing documentation may cover:
+It must not present historical project testing as current automated coverage.
 
-- automated tests;
-- manual regression tests;
-- smoke tests;
-- edge-case validation;
-- static-analysis checks;
-- memory and resource validation;
-- continuous-integration checks.
+## Current State
 
-Only validation material that has been reviewed against the maintained
-implementation should be promoted into this directory.
+The maintained repository currently has:
 
-Original evaluation preparation and historical test evidence remain under
-[`../history/validation/`](../history/validation/) until they are audited.
+| Capability | Current state |
+| --- | --- |
+| Local build validation | Available through `make` |
+| Pull-request build validation | Automated through GitHub Actions |
+| Manual behavioural validation | Maintained practice |
+| Memory validation | Manual, using Valgrind where relevant |
+| File-descriptor validation | Manual, using Valgrind `--track-fds=yes` where relevant |
+| Automated regression tests | Not implemented |
+| Automated behavioural tests in CI | Not implemented |
+| Static-analysis automation | Not implemented |
+| Coverage reporting | Not implemented |
 
-The current testing strategy will be established through the dedicated testing
-modernization workstream.
+A successful CI run currently demonstrates that the project builds in the CI
+environment. It does not demonstrate complete behavioural correctness,
+resource safety or regression coverage.
+
+## Maintained Documentation
+
+The current validation model is documented in:
+
+- [`validation-strategy.md`](validation-strategy.md), which defines validation
+  layers, expectations by change type, evidence standards, CI boundaries and
+  known testing gaps.
+
+A maintained manual-validation guide is developed separately within this
+testing workstream.
+
+## Historical Validation Evidence
+
+Original 42 evaluation preparation and project-era validation remain preserved
+under:
+
+[`../history/validation/`](../history/validation/)
+
+The historical material currently includes:
+
+- [`mandatory-test-matrix.md`](../history/validation/mandatory-test-matrix.md),
+  a broad mandatory-scope manual evaluation matrix;
+- [`MSH-12-expansion-tests.md`](../history/validation/MSH-12-expansion-tests.md),
+  focused expansion and exit-status validation evidence;
+- [`MSH-14-builtin-tests.md`](../history/validation/MSH-14-builtin-tests.md),
+  detailed builtin, build, Norminette, Valgrind and file-descriptor validation
+  evidence.
+
+These documents are useful evidence of how the original project was validated.
+
+They are not an automated test suite and are not silently promoted to current
+test results.
+
+## Validation Evidence
+
+Current validation claims should identify what was actually checked.
+
+Examples include:
+
+```text
+make
+manual command sequence
+Valgrind invocation
+file-descriptor inspection
+documentation link audit
+configuration-schema validation
+GitHub functional verification
+```
+
+A pull request should not claim a category of validation merely because a
+historical document contains tests for that category.
+
+## Related Documentation
+
+- [`../development/git-workflow.md`](../development/git-workflow.md) defines
+  where validation fits into the issue-to-merge workflow.
+- [`../architecture/resource-ownership.md`](../architecture/resource-ownership.md)
+  documents memory and file-descriptor ownership.
+- [`../architecture/process-and-signals.md`](../architecture/process-and-signals.md)
+  documents process and signal behaviour relevant to validation.
+- [`../history/README.md`](../history/README.md) defines the role of historical
+  project material.

--- a/docs/testing/manual-validation.md
+++ b/docs/testing/manual-validation.md
@@ -1,0 +1,516 @@
+# Manual Validation
+
+This guide provides maintained, reproducible manual checks for the current
+Minishell implementation.
+
+It complements
+[`validation-strategy.md`](validation-strategy.md).
+
+The commands below are validation procedures, not claims that every check has
+already been executed against every commit.
+
+Historical project-era results remain preserved separately under
+[`../history/validation/`](../history/validation/).
+
+## How to Use This Guide
+
+Choose validation proportional to the change.
+
+A documentation-only pull request does not require an interactive Minishell
+regression run merely to satisfy a checklist.
+
+A source change should validate the affected behaviour together with nearby
+regression risks.
+
+For each validation session, record:
+
+- the build or commit being tested;
+- the commands or interaction performed;
+- the observed result;
+- any relevant exit status;
+- failures or deviations;
+- resource-tool output where applicable.
+
+## 1. Clean Build
+
+From the repository root:
+
+```bash
+make fclean
+make
+```
+
+Expected result:
+
+- compilation completes successfully;
+- the `minishell` executable is produced;
+- compiler flags remain `-Wall -Wextra -Werror`.
+
+A second build may be used to check that an unchanged tree does not rebuild
+unnecessarily:
+
+```bash
+make
+```
+
+The current Makefile does not provide a `test` target.
+
+## 2. Start the Shell
+
+Run:
+
+```bash
+./minishell
+```
+
+Confirm that:
+
+- the prompt appears;
+- an empty input line does not terminate the shell;
+- normal commands return control to the prompt;
+- the shell remains usable after recoverable errors.
+
+Exit with:
+
+```text
+exit
+```
+
+## 3. Basic Command Execution
+
+Inside Minishell:
+
+```text
+echo hello
+pwd
+/bin/echo absolute
+echo external
+```
+
+Check that:
+
+- builtins execute successfully;
+- absolute executable paths work;
+- commands resolvable through `PATH` execute;
+- control returns to the prompt.
+
+For an unknown command:
+
+```text
+definitely_not_a_command
+echo $?
+```
+
+The maintained implementation should report command-not-found behaviour and
+store the corresponding shell status.
+
+The historical mandatory validation expected status `127` for this case.
+
+## 4. Quotes and Expansion
+
+Use representative quote and expansion cases:
+
+```text
+echo '$HOME'
+echo "$HOME"
+echo $HOME
+echo "$THIS_VARIABLE_SHOULD_NOT_EXIST"
+```
+
+Check that:
+
+- single quotes preserve `$HOME` literally;
+- double quotes allow expansion;
+- unquoted variables expand;
+- a missing variable expands according to the maintained implementation.
+
+Check the previous exit status:
+
+```text
+pwd
+echo $?
+definitely_not_a_command
+echo $?
+```
+
+When changing scanning or expansion code, also include concatenated segments
+such as:
+
+```text
+echo "prefix"$HOME
+echo 'literal'"$HOME"
+```
+
+## 5. Syntax Error Recovery
+
+Try malformed input such as:
+
+```text
+echo "unterminated
+```
+
+and malformed operators relevant to the implementation, for example:
+
+```text
+echo hello |
+```
+
+Confirm that:
+
+- the shell reports the error;
+- it does not crash;
+- it returns to a usable prompt;
+- subsequent commands still execute.
+
+Record the resulting `$?` when the change affects syntax-status behaviour.
+
+## 6. Builtins and Persistent Shell State
+
+Representative standalone builtin checks include:
+
+```text
+pwd
+cd /tmp
+pwd
+cd /does/not/exist
+echo $?
+```
+
+Environment mutation may be checked with:
+
+```text
+export MINISHELL_VALIDATION=hello
+echo $MINISHELL_VALIDATION
+export MINISHELL_VALIDATION=world
+echo $MINISHELL_VALIDATION
+unset MINISHELL_VALIDATION
+echo "$MINISHELL_VALIDATION"
+```
+
+Check that standalone stateful builtins mutate the parent shell as expected.
+
+When relevant, also verify that a stateful builtin executed inside a pipeline
+does not incorrectly mutate persistent parent-shell state.
+
+## 7. Redirections
+
+Create disposable fixtures before or during validation.
+
+Representative checks include:
+
+```text
+echo first > validation-output.txt
+cat validation-output.txt
+echo second >> validation-output.txt
+cat validation-output.txt
+cat < validation-output.txt
+```
+
+Check:
+
+- truncate output redirection;
+- append redirection;
+- input redirection;
+- creation and reuse of files;
+- return to normal terminal input/output afterward.
+
+For redirection failure:
+
+```text
+cat < file-that-does-not-exist
+echo $?
+```
+
+Confirm that the shell remains usable after the error.
+
+Remove validation artefacts afterward:
+
+```text
+rm -f validation-output.txt
+```
+
+## 8. Pipelines
+
+Representative pipeline checks include:
+
+```text
+printf 'a\nb\n' | wc -l
+echo hello | cat
+printf 'a\nb\nc\n' | grep b | wc -l
+```
+
+Check:
+
+- two-stage pipelines;
+- multi-stage pipelines;
+- data flow between stages;
+- shell continuity afterward.
+
+When pipeline status behaviour is relevant, execute a pipeline and inspect:
+
+```text
+echo $?
+```
+
+The maintained implementation uses the foreground pipeline result for the
+shell's persistent last status.
+
+## 9. Redirections with Pipelines
+
+Combine the two mechanisms when execution or descriptor ownership changes:
+
+```text
+printf 'a\nb\n' > validation-input.txt
+cat < validation-input.txt | wc -l
+cat validation-input.txt | grep b > validation-output.txt
+cat validation-output.txt
+```
+
+Confirm that:
+
+- input redirection reaches the intended command;
+- pipeline descriptors are connected correctly;
+- output redirection applies to the intended stage;
+- later prompt iterations still use normal standard input and output.
+
+Clean up:
+
+```text
+rm -f validation-input.txt validation-output.txt
+```
+
+## 10. Heredoc
+
+Run:
+
+```text
+cat << EOF
+line one
+line two
+EOF
+```
+
+Confirm that:
+
+- input is collected until the delimiter;
+- the resulting content reaches the command;
+- the prompt returns afterward.
+
+When expansion behaviour is under test, check an unquoted delimiter using a
+known environment variable.
+
+When quoted-delimiter semantics are relevant to the change, validate them
+against the maintained implementation and record the observed result.
+
+## 11. Interactive Signals
+
+Signal validation must be performed in an interactive terminal.
+
+### Prompt context
+
+At an empty Minishell prompt:
+
+- press `Ctrl-C`;
+- confirm that the shell remains running;
+- confirm that a fresh prompt is presented.
+
+Test `Ctrl-\` separately and record the observed prompt behaviour.
+
+Use `Ctrl-D` at an empty prompt to verify end-of-input handling.
+
+### Foreground command
+
+Run a foreground process such as:
+
+```text
+cat
+```
+
+Then press `Ctrl-C`.
+
+Confirm that:
+
+- the foreground process is interrupted;
+- Minishell itself remains running;
+- the prompt returns;
+- `$?` reflects signal-derived termination according to the maintained process
+  model.
+
+Signal-derived process status is documented in:
+
+[`../architecture/process-and-signals.md`](../architecture/process-and-signals.md)
+
+### Heredoc context
+
+When heredoc signal handling is affected, start:
+
+```text
+cat << EOF
+```
+
+and press `Ctrl-C` before supplying the delimiter.
+
+Confirm that:
+
+- heredoc collection is interrupted;
+- the shell returns to its interactive state;
+- subsequent commands remain usable.
+
+## 12. Memory Validation
+
+For changes that affect allocation ownership or long-lived shell state, run:
+
+```bash
+valgrind \
+  --leak-check=full \
+  --show-leak-kinds=all \
+  ./minishell
+```
+
+Exercise representative affected paths before exiting.
+
+Inspect separately:
+
+- definitely lost memory;
+- indirectly lost memory;
+- possibly lost memory;
+- still-reachable allocations;
+- Valgrind error summaries.
+
+Do not classify every reachable allocation as a Minishell leak.
+
+Historical validation identified reachable allocations associated with
+Readline and related libraries. Current results still need to be interpreted
+against actual ownership rather than copied from historical summaries.
+
+See:
+
+[`../architecture/resource-ownership.md`](../architecture/resource-ownership.md)
+
+## 13. File-Descriptor Validation
+
+For execution, pipelines, heredocs and redirections, include descriptor
+tracking:
+
+```bash
+valgrind \
+  --leak-check=full \
+  --show-leak-kinds=all \
+  --track-fds=yes \
+  ./minishell
+```
+
+Exercise representative scenarios such as:
+
+```text
+echo hello | cat
+printf 'a\nb\n' | grep b | wc -l
+echo hello > validation-output.txt
+cat < validation-output.txt
+cat << EOF
+heredoc
+EOF
+```
+
+After leaving Minishell, inspect Valgrind's descriptor report.
+
+The relevant question is not simply whether descriptors existed during
+execution, but whether shell-owned descriptors that should have been released
+remain open at exit.
+
+Clean up any generated files afterward.
+
+## 14. Validation After an Error
+
+Error paths deserve explicit regression checks because they often exercise
+different cleanup paths.
+
+Representative cases include:
+
+```text
+definitely_not_a_command
+cat < file-that-does-not-exist
+cd /does/not/exist
+echo hello |
+```
+
+After each case:
+
+1. observe the error;
+2. inspect `$?` when relevant;
+3. run a normal command such as `echo recovered`;
+4. confirm that Minishell remains usable.
+
+For resource-sensitive changes, include failure paths in Valgrind and FD
+validation rather than testing only successful commands.
+
+## 15. Documentation and Repository Changes
+
+Changes that do not affect runtime behaviour should use validation appropriate
+to the artefact.
+
+Typical checks include:
+
+```bash
+git status
+git diff --check
+git diff
+```
+
+Additional checks may include:
+
+- Markdown link validation;
+- YAML parsing;
+- GitHub-specific configuration validation;
+- rendered GitHub behaviour;
+- documentation structure audits.
+
+Do not claim runtime testing if runtime behaviour was not changed or exercised.
+
+## 16. Recording Results in a Pull Request
+
+Report only validation actually performed.
+
+A useful record looks like:
+
+```text
+Validation:
+- make fclean && make
+- manual expansion regression:
+  - echo '$HOME'
+  - echo "$HOME"
+  - invalid command followed by echo $?
+- Valgrind with --track-fds=yes on representative redirection paths
+```
+
+For documentation-only work:
+
+```text
+Validation:
+- git diff --check
+- local Markdown link audit
+```
+
+Avoid vague claims such as:
+
+```text
+All tests pass.
+```
+
+unless a defined test suite was actually executed.
+
+## Historical Scenario Reference
+
+The historical validation documents remain useful sources of scenarios:
+
+- [`mandatory-test-matrix.md`](../history/validation/mandatory-test-matrix.md)
+  provides broad mandatory-subsystem coverage;
+- [`MSH-12-expansion-tests.md`](../history/validation/MSH-12-expansion-tests.md)
+  provides focused expansion scenarios;
+- [`MSH-14-builtin-tests.md`](../history/validation/MSH-14-builtin-tests.md)
+  provides extensive builtin, status and resource scenarios.
+
+Using a historical scenario as a current manual check is valid.
+
+A historical PASS result by itself is not evidence that the current baseline
+was revalidated.

--- a/docs/testing/validation-strategy.md
+++ b/docs/testing/validation-strategy.md
@@ -1,0 +1,319 @@
+# Validation Strategy
+
+This document defines the maintained validation strategy for Minishell.
+
+The goal is not to imply test infrastructure that the repository does not yet
+have.
+
+Instead, the strategy identifies which checks are currently available, when
+they should be used and what evidence is required before making a validation
+claim.
+
+## Principles
+
+Validation should be:
+
+- proportional to the change;
+- reproducible where practical;
+- explicit about what was and was not checked;
+- separated from historical project evidence;
+- focused on observable behaviour and repository invariants;
+- expanded through automation only when the automation actually exists.
+
+A green build is evidence of successful compilation.
+
+It is not evidence that every shell behaviour, signal path, memory lifetime or
+file-descriptor transition is correct.
+
+## Validation Layers
+
+The maintained model uses several validation layers.
+
+### 1. Repository and Static Validation
+
+These checks inspect repository artefacts rather than shell runtime behaviour.
+
+Examples include:
+
+```bash
+git status
+git diff --check
+git diff
+```
+
+Depending on the change, this layer may also include:
+
+- Markdown link validation;
+- YAML or configuration parsing;
+- platform-specific schema validation;
+- rendered GitHub configuration checks;
+- Norminette for source files where 42-style constraints remain applicable.
+
+The exact check should match the artefact being changed.
+
+### 2. Build Validation
+
+The primary local build check is:
+
+```bash
+make
+```
+
+A broader clean-build check may use:
+
+```bash
+make fclean
+make
+```
+
+Build validation confirms that the project compiles with the repository's
+configured compiler flags and dependencies.
+
+The current Makefile does not define a `test` target.
+
+### 3. Behavioural Validation
+
+Shell behaviour currently requires manual validation.
+
+Relevant areas include:
+
+- prompt continuity;
+- quoting;
+- variable expansion;
+- `$?`;
+- builtins;
+- external command execution;
+- PATH resolution;
+- redirections;
+- heredocs;
+- pipelines;
+- syntax errors;
+- command failures;
+- signals;
+- shell-state persistence.
+
+The maintained strategy does not describe these behaviours as automatically
+covered.
+
+Representative manual checks should be selected according to the subsystem
+changed and recorded as validation evidence.
+
+Historical test matrices may be consulted for useful scenarios, but executing
+a current check is distinct from citing a historical result.
+
+### 4. Resource Validation
+
+Changes affecting execution, pipelines, redirections, heredocs, builtins or
+state ownership may require resource validation.
+
+Relevant concerns include:
+
+- shell-owned memory;
+- file-descriptor lifetime;
+- descriptor closure across pipelines;
+- temporary parent redirections;
+- heredoc descriptors;
+- child-process cleanup.
+
+Valgrind remains a useful manual tool for these checks.
+
+A representative invocation is:
+
+```bash
+valgrind \
+  --leak-check=full \
+  --show-leak-kinds=all \
+  --track-fds=yes \
+  ./minishell
+```
+
+Results must be interpreted in context.
+
+Historical validation records note that reachable allocations originating from
+Readline or related libraries may appear separately from shell-owned memory.
+
+A current validation claim should distinguish library-owned reachable memory
+from leaks introduced by Minishell.
+
+For the maintained ownership model, see:
+
+- [`../architecture/resource-ownership.md`](../architecture/resource-ownership.md)
+- [`../architecture/process-and-signals.md`](../architecture/process-and-signals.md)
+
+### 5. Automated Regression Validation
+
+A maintained automated regression suite is not currently implemented.
+
+There is currently:
+
+- no repository `tests/` directory;
+- no executable Minishell test script;
+- no Makefile `test` target;
+- no automated behavioural regression job;
+- no automated Valgrind or file-descriptor job;
+- no coverage reporting.
+
+These are testing gaps, not implicit capabilities.
+
+Automation can be introduced through later dedicated workstreams without
+rewriting historical evidence as if it were executable coverage.
+
+## Validation by Change Type
+
+The expected depth of validation depends on the change.
+
+| Change type | Expected validation |
+| --- | --- |
+| Documentation only | Diff checks, links and relevant rendered/document structure checks |
+| GitHub configuration | Syntax/schema validation plus platform behaviour where applicable |
+| Build or dependency configuration | Clean build and relevant CI execution |
+| Localized source change | Build plus focused behavioural regression |
+| Parser / expansion change | Build plus relevant syntax, quote, expansion and status cases |
+| Builtin / shell-state change | Build plus state persistence, error status and relevant redirection cases |
+| Execution / pipeline change | Build plus pipelines, status propagation and resource checks |
+| Redirection / heredoc change | Build plus descriptor, error-path, heredoc and resource checks |
+| Signal-sensitive change | Build plus interactive and foreground-process signal checks |
+| Resource-ownership change | Build plus representative Valgrind and FD validation |
+| CI-only change | Workflow/config validation and observation of the resulting GitHub check |
+
+These are maintained expectations, not claims that every row is automated.
+
+## Current CI Capability
+
+The current GitHub Actions workflow is:
+
+[`../../.github/workflows/ci.yml`](../../.github/workflows/ci.yml)
+
+It runs for:
+
+- pull requests;
+- pushes to `main`.
+
+The current job:
+
+1. checks out the repository;
+2. installs `libreadline-dev`;
+3. runs `make` when the Makefile exists.
+
+Therefore, the current CI provides automated build validation only.
+
+It does not currently run:
+
+- behavioural regression tests;
+- Norminette;
+- Valgrind;
+- file-descriptor checks;
+- signal-interaction tests;
+- static analysis;
+- coverage reporting.
+
+These limitations should remain visible until the corresponding automation is
+actually implemented.
+
+## Historical Evidence
+
+Historical validation lives under:
+
+[`../history/validation/`](../history/validation/)
+
+The preserved material has different purposes.
+
+### Mandatory Test Matrix
+
+[`mandatory-test-matrix.md`](../history/validation/mandatory-test-matrix.md)
+contains broad manual evaluation preparation covering the mandatory project
+scope, including prompt behaviour, quoting, operators, expansion, builtins,
+external execution, redirections, pipelines, signals and error statuses.
+
+It is the broadest historical behavioural reference.
+
+### Expansion Validation
+
+[`MSH-12-expansion-tests.md`](../history/validation/MSH-12-expansion-tests.md)
+records focused project-era validation of:
+
+- environment expansion;
+- quote-sensitive expansion;
+- missing variables;
+- `$?`;
+- syntax continuity;
+- a basic Valgrind pass.
+
+It is historical evidence, not a current automated expansion suite.
+
+### Builtin Validation
+
+[`MSH-14-builtin-tests.md`](../history/validation/MSH-14-builtin-tests.md)
+records extensive project-era validation of builtins together with build,
+Norminette, error-status, redirection, Valgrind and file-descriptor checks.
+
+Its recorded PASS results describe the historical validation event.
+
+They must not be presented as automatically revalidated on the current
+baseline.
+
+## Recording Validation Evidence
+
+A useful validation record answers three questions:
+
+1. What was checked?
+2. How was it checked?
+3. What was observed?
+
+For example:
+
+```text
+Validation:
+- make
+- manual pipeline regression:
+  printf 'a\nb\n' | wc -l
+- Valgrind:
+  --leak-check=full --show-leak-kinds=all --track-fds=yes
+```
+
+Avoid statements such as:
+
+```text
+All tests pass.
+```
+
+when no defined automated test suite was executed.
+
+Prefer precise claims such as:
+
+```text
+The CI build passed and the affected pipeline scenarios were manually
+validated.
+```
+
+## Known Gaps and Future Automation
+
+The current repository still lacks automated regression coverage.
+
+Future testing work may consider:
+
+- executable behavioural regression tests;
+- reusable fixtures and expected-output comparisons;
+- non-interactive cases where shell semantics allow reliable automation;
+- dedicated interactive testing where terminal behaviour matters;
+- CI integration for maintained regression tests;
+- automated resource checks where results can be interpreted reliably;
+- coverage reporting where it provides useful engineering information.
+
+Static analysis and broader CI quality gates are separate modernization
+workstreams.
+
+Testing automation should be added as executable infrastructure, not inferred
+from historical Markdown test matrices.
+
+## Relationship to the Development Workflow
+
+Validation is part of the maintained contribution lifecycle documented in:
+
+[`../development/git-workflow.md`](../development/git-workflow.md)
+
+The pull request should report validation actually performed.
+
+Documentation-only work should not claim runtime testing that was not needed or
+performed, while behaviour-changing source work should provide evidence
+proportional to its risk.


### PR DESCRIPTION
## Linked issue

Closes #40

## Summary

Establish the maintained testing and validation documentation structure for the
repository.

This pull request:

- defines the current validation strategy and its boundaries;
- documents reproducible manual validation procedures;
- distinguishes maintained validation from historical 42 project evidence;
- documents validation expectations by change type;
- describes build, behavioural, signal, exit-status, memory and file-descriptor
  validation;
- documents the exact capabilities and limitations of the current CI workflow;
- records automated regression testing and broader quality automation as future
  work;
- aligns the root and documentation indexes with the new maintained testing
  domain.

## Why

The repository previously preserved substantial historical validation evidence
but did not have a maintained testing model explaining what can be validated
today.

The existing CI workflow also performs only a build check, while the repository
documentation referenced broader testing work primarily as future
modernization.

This change creates a clear boundary between:

1. current maintained validation guidance;
2. historical project-era validation evidence;
3. future automated regression infrastructure.

This prevents historical PASS results or manual test matrices from being
mistaken for current automated coverage.

## Scope

### Included

- `docs/testing/README.md`
- `docs/testing/validation-strategy.md`
- `docs/testing/manual-validation.md`
- testing and validation navigation in `README.md`
- testing-domain status and navigation in `docs/README.md`

### Out of scope

- source-code behaviour changes
- Makefile changes
- CI workflow changes
- creation of a `tests/` directory
- automated regression tests
- automated Valgrind or file-descriptor checks
- static-analysis automation
- coverage reporting
- modification of historical validation evidence

## Validation

- repository audit of existing testing and validation material
- `git diff --check`
- Markdown/code-fence validation
- local documentation-link audit
- testing integration audit across the affected documentation
- explicit comparison against `origin/main`
- verification that historical validation files are unchanged
- verification that source, Makefile and libft are unchanged
- verification that the CI workflow is unchanged
- issue #40 acceptance-criteria audit

### Validation details

Final branch audit:

```text
Changed files: 5
Historical validation files unchanged: PASS
Source/build behaviour files unchanged: PASS
CI workflow unchanged: PASS
git diff --check: PASS
```

Testing integration audit:

```text
Files checked: 5
Local links: 40
Errors: 0
Testing integration audit: PASS
```

Issue acceptance audit:

```text
Changed files: 5
Errors: 0
Issue #40 acceptance audit: PASS
```

No runtime behavioural testing was performed because this pull request changes
documentation only and introduces no source or build behaviour changes.

## Review notes

The most important review boundary is the distinction between maintained
validation guidance and historical evidence.

The current GitHub Actions workflow is intentionally documented as build-only.
This pull request does not claim that behavioural testing, Valgrind, FD checks,
static analysis or coverage are automated.

Historical validation under `docs/history/validation/` remains unchanged and
continues to represent project-era evidence rather than automatically
revalidated results.

## Checklist

- [x] Linked issue is included
- [x] Scope is limited to the testing documentation workstream
- [x] Documentation reflects the maintained repository
- [x] Historical and maintained validation are clearly separated
- [x] Current CI capabilities and limitations are represented accurately
- [x] Documentation links were validated
- [x] `git diff --check` passes
- [x] No source behaviour changes are included
- [x] Validation performed is documented above