### PR TITLE
ci: establish continuous integration baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,28 +3,57 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [ main ]
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
 
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
-      - name: Install dependencies
-        shell: bash
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libreadline-dev
-
-      - name: Build (if Makefile exists)
+      - name: Install build dependencies
         shell: bash
         run: |
           set -euo pipefail
-          if [ -f Makefile ]; then
-            make
-          else
-            echo "No Makefile yet, skipping build."
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libreadline-dev
+
+      - name: Clean build
+        shell: bash
+        run: |
+          set -euo pipefail
+          make fclean
+          make
+
+      - name: Verify build artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -x ./minishell
+
+      - name: Verify no relink
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          before="$(stat -c '%y' ./minishell)"
+          make
+          after="$(stat -c '%y' ./minishell)"
+
+          if [ "$before" != "$after" ]; then
+            echo "minishell was unexpectedly relinked"
+            exit 1
           fi

--- a/README.md
+++ b/README.md
@@ -437,10 +437,16 @@ See:
   for reproducible manual checks covering shell behaviour, signals, memory,
   file descriptors and repository changes.
 
-The current GitHub Actions workflow provides automated build validation on pull
-requests and pushes to `main`. It currently runs `make`; it does not provide an
-automated behavioural regression suite, resource checks, static analysis or
-coverage reporting.
+The current GitHub Actions workflow provides automated build-integration
+validation on pull requests and pushes to `main`. It performs a clean build,
+verifies the expected executable and checks that an unchanged second `make`
+does not relink it.
+
+The CI baseline and its failure semantics are documented in
+[`docs/development/continuous-integration.md`](docs/development/continuous-integration.md).
+
+The workflow does not currently provide an automated behavioural regression
+suite, resource checks, static analysis or coverage reporting.
 
 Original 42 evaluation preparation and project-era validation evidence remain
 preserved under

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -14,7 +14,9 @@ For contributors and maintainers beginning from the repository root:
 - [`../../CONTRIBUTING.md`](../../CONTRIBUTING.md) provides the public
   contribution entry point;
 - [`git-workflow.md`](git-workflow.md) documents the detailed Git and GitHub
-  lifecycle.
+  lifecycle;
+- [`continuous-integration.md`](continuous-integration.md) documents the
+  maintained GitHub Actions build baseline, its guarantees and its limitations.
 
 ## Current Workflow
 
@@ -54,6 +56,7 @@ The detailed workflow covers:
 - pull-request expectations;
 - maintained GitHub Issue Forms and pull-request templates;
 - CI and review;
+- the maintained continuous-integration baseline;
 - `CODEOWNERS`;
 - protected `main` behaviour;
 - squash merge;
@@ -63,6 +66,10 @@ The detailed workflow covers:
 See:
 
 [`git-workflow.md`](git-workflow.md)
+
+For the CI contract itself, see:
+
+[`continuous-integration.md`](continuous-integration.md)
 
 ## Repository Governance
 

--- a/docs/development/continuous-integration.md
+++ b/docs/development/continuous-integration.md
@@ -1,0 +1,327 @@
+# Continuous Integration
+
+This document describes the maintained continuous-integration baseline for the
+repository.
+
+The current GitHub Actions workflow provides build integration checks. It is
+deliberately narrower than a complete quality gate.
+
+The authoritative workflow configuration is:
+
+[`../../.github/workflows/ci.yml`](../../.github/workflows/ci.yml)
+
+## Purpose
+
+The CI baseline answers a focused question:
+
+> Can the repository be checked out in the maintained CI environment and
+> produce the expected Minishell executable through a clean, stable build?
+
+The workflow also checks one important Makefile invariant: rebuilding an
+unchanged tree must not relink the final executable.
+
+The workflow does not currently claim behavioural test coverage.
+
+## When CI Runs
+
+The workflow is triggered by:
+
+- pull requests;
+- pushes to `main`.
+
+A normal feature-branch push does not run this workflow by itself.
+
+For the maintained contribution lifecycle, this means:
+
+```text
+feature branch push
+        |
+        v
+no CI run required yet
+
+pull request opened or updated
+        |
+        v
+CI / build
+
+squash merge to main
+        |
+        v
+CI / build
+```
+
+Pull-request runs that are superseded by newer commits are cancelled.
+
+Push runs on `main` are not cancelled by that pull-request policy.
+
+## Execution Environment
+
+The build job currently uses:
+
+```text
+ubuntu-24.04
+```
+
+The runner version is explicit rather than using `ubuntu-latest`.
+
+This reduces accidental changes to the CI environment when GitHub advances the
+meaning of its `latest` runner alias.
+
+The workflow has a job timeout of:
+
+```text
+10 minutes
+```
+
+A build that exceeds that limit fails rather than occupying a runner
+indefinitely.
+
+## Workflow Permissions
+
+The workflow declares:
+
+```yaml
+permissions:
+  contents: read
+```
+
+The build needs repository contents but does not need write access.
+
+The checkout step also uses:
+
+```yaml
+persist-credentials: false
+```
+
+because the job does not push commits, create tags or modify repository state.
+
+These settings keep the build workflow read-only at the repository level.
+
+## Build Dependency
+
+The external system dependency required by the maintained build is:
+
+```text
+libreadline-dev
+```
+
+The workflow installs it with:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends libreadline-dev
+```
+
+GNU Readline is linked by the project Makefile through:
+
+```text
+-lreadline
+```
+
+The repository's own `libft` is built from the checked-out source tree rather
+than installed as a system dependency.
+
+## Build Pipeline
+
+The current `build` job performs the following checks.
+
+### 1. Checkout Repository
+
+The repository is checked out using:
+
+```text
+actions/checkout@v4
+```
+
+No persisted Git credentials are required after checkout.
+
+### 2. Install Build Dependencies
+
+The workflow installs the GNU Readline development package required to compile
+and link Minishell.
+
+### 3. Clean Build
+
+The workflow executes:
+
+```bash
+make fclean
+make
+```
+
+Starting from `make fclean` makes the build check explicit even though GitHub
+Actions already provides a fresh checkout for each job.
+
+The build therefore validates that the project can be rebuilt from its own
+clean state rather than succeeding only because generated objects already
+exist.
+
+### 4. Verify the Build Artifact
+
+After compilation, the workflow checks:
+
+```bash
+test -x ./minishell
+```
+
+A successful compiler exit alone is not treated as sufficient if the expected
+executable is missing or is not executable.
+
+### 5. Verify No Relink
+
+The workflow records the modification timestamp of `./minishell`, executes:
+
+```bash
+make
+```
+
+again and compares the timestamp afterward.
+
+If the timestamp changes, CI fails.
+
+This checks that an unchanged repository does not unnecessarily relink the
+final executable.
+
+The local discovery audit for the CI workstream confirmed that the current
+Makefile already satisfies this property:
+
+```text
+make: Nothing to be done for 'all'.
+```
+
+The workflow therefore validates an existing Makefile invariant. It does not
+modify the Makefile to create one.
+
+## Failure Semantics
+
+A failed `CI / build` check means that at least one maintained build-integration
+requirement was not satisfied.
+
+Examples include:
+
+- the dependency installation failed;
+- `make fclean` failed;
+- the clean build failed;
+- the expected `minishell` executable was not produced;
+- the executable was not executable;
+- an unchanged second `make` relinked the executable;
+- the build exceeded the configured timeout;
+- another workflow step terminated unsuccessfully.
+
+A failed build check does not identify every possible runtime defect.
+
+Conversely, a successful build check does not prove complete Minishell
+correctness.
+
+## Concurrency Behaviour
+
+The workflow groups runs using the workflow identity together with the pull
+request number or Git reference.
+
+For pull requests:
+
+```text
+new commit pushed
+       |
+       v
+new CI run starts
+       |
+       +--> older in-progress run is cancelled
+```
+
+This avoids spending runner time on an obsolete revision of the same pull
+request.
+
+For non-pull-request events, including pushes to `main`, the cancellation
+condition is false.
+
+## What CI Currently Guarantees
+
+A successful current CI run provides evidence that:
+
+- the repository can be checked out by GitHub Actions;
+- the declared build dependency can be installed;
+- the project can complete a clean build on Ubuntu 24.04;
+- the expected `minishell` executable is produced;
+- the executable is marked executable;
+- an unchanged second `make` does not relink the executable.
+
+These are build-integration guarantees only.
+
+## What CI Does Not Currently Guarantee
+
+The current workflow does not run:
+
+- behavioural regression tests;
+- interactive shell tests;
+- signal-behaviour tests;
+- Norminette;
+- Valgrind;
+- file-descriptor leak checks;
+- static analysis;
+- code-coverage reporting.
+
+Those capabilities must not be inferred from a green `CI / build` result.
+
+The maintained testing model is documented under:
+
+[`../testing/`](../testing/)
+
+In particular:
+
+- [`../testing/validation-strategy.md`](../testing/validation-strategy.md)
+  defines current validation layers and testing gaps;
+- [`../testing/manual-validation.md`](../testing/manual-validation.md)
+  defines reproducible manual validation procedures.
+
+## Relationship to Future Quality Automation
+
+This CI baseline intentionally provides a stable foundation rather than
+collecting every future quality check into one workstream.
+
+Separate modernization work can later introduce:
+
+- automated regression testing;
+- static analysis and other quality checks;
+- additional CI jobs where they provide demonstrated value.
+
+When those capabilities are actually implemented, this document and the
+testing documentation should be updated to describe the expanded CI contract.
+
+## Relationship to Branch Protection
+
+The maintained repository uses pull requests and protected `main` governance.
+
+The workflow's stable identity remains:
+
+```text
+CI / build
+```
+
+Keeping the workflow name `CI` and job identifier `build` avoids unnecessarily
+changing the status-check identity while the baseline itself is improved.
+
+Repository-governance details are documented in:
+
+[`git-workflow.md`](git-workflow.md)
+
+## Local Equivalent
+
+The central build behaviour can be reproduced locally with:
+
+```bash
+make fclean
+make
+
+test -x ./minishell
+
+before="$(stat -c '%y' ./minishell)"
+make
+after="$(stat -c '%y' ./minishell)"
+
+test "$before" = "$after"
+```
+
+The GitHub-specific parts, including runner selection, permissions,
+pull-request concurrency and status-check behaviour, require an actual GitHub
+Actions run for final validation.

--- a/docs/development/git-workflow.md
+++ b/docs/development/git-workflow.md
@@ -449,7 +449,11 @@ the authoritative description of the full repository workflow.
 
 ## 9. CI and Validation on GitHub
 
-The repository currently defines:
+The maintained continuous-integration baseline is documented in:
+
+[`continuous-integration.md`](continuous-integration.md)
+
+and implemented by:
 
 [`../../.github/workflows/ci.yml`](../../.github/workflows/ci.yml)
 
@@ -458,15 +462,23 @@ The workflow runs:
 - for pull requests;
 - for pushes to `main`.
 
-Its current job installs the readline development dependency and builds the
-project when a `Makefile` exists.
+The current `CI / build` job uses Ubuntu 24.04, installs the Readline
+development dependency and validates:
 
-A successful build is useful evidence that the pull request still compiles.
+- a clean `make fclean && make` build;
+- creation of the executable `./minishell`;
+- no unnecessary relink when `make` is immediately repeated.
 
-The current CI workflow should not be described as a complete quality gate.
+The workflow uses explicit read-only repository permissions, a job timeout and
+pull-request concurrency cancellation for superseded runs.
 
-Automated tests, static analysis and broader quality checks belong to separate
-modernization workstreams.
+A successful `CI / build` result is evidence that these build-integration
+requirements passed.
+
+It is not evidence of complete behavioural correctness.
+
+Automated regression tests, static analysis, Valgrind, FD checks and broader
+quality automation belong to separate modernization workstreams.
 
 Before merge, confirm that the available checks have completed successfully.
 

--- a/docs/testing/validation-strategy.md
+++ b/docs/testing/validation-strategy.md
@@ -184,18 +184,28 @@ The current GitHub Actions workflow is:
 
 [`../../.github/workflows/ci.yml`](../../.github/workflows/ci.yml)
 
+The detailed CI contract is documented in:
+
+[`../development/continuous-integration.md`](../development/continuous-integration.md)
+
 It runs for:
 
 - pull requests;
 - pushes to `main`.
 
-The current job:
+The current `CI / build` job:
 
 1. checks out the repository;
 2. installs `libreadline-dev`;
-3. runs `make` when the Makefile exists.
+3. performs `make fclean && make`;
+4. verifies that `./minishell` is executable;
+5. verifies that an unchanged second `make` does not relink the executable.
 
-Therefore, the current CI provides automated build validation only.
+The workflow also defines explicit read-only repository permissions, a
+10-minute job timeout and cancellation of superseded pull-request runs.
+
+Therefore, the current CI provides automated build-integration validation
+only.
 
 It does not currently run:
 


### PR DESCRIPTION
## Linked issue

Closes #42

## Summary

Establish a deliberate continuous-integration baseline for the maintained
repository.

This pull request:

- makes the CI execution environment explicit with Ubuntu 24.04;
- applies read-only repository permissions;
- avoids persisting checkout credentials;
- cancels superseded pull-request CI runs;
- adds a 10-minute build timeout;
- performs a clean `make fclean && make` build;
- verifies that the expected `minishell` executable is produced;
- verifies that an unchanged second `make` does not relink the executable;
- documents the CI contract, failure semantics and current limitations;
- keeps behavioural testing, resource checks and static analysis outside this
  workstream.

## Why

The repository already had a minimal GitHub Actions workflow that installed the
Readline development dependency and ran `make`.

That workflow provided useful build feedback but left several aspects implicit:

- the runner followed the moving `ubuntu-latest` alias;
- repository permissions were not explicitly declared;
- obsolete pull-request runs were not cancelled;
- no timeout was configured;
- the build silently succeeded if the Makefile was missing;
- the expected executable was not explicitly verified;
- the Makefile no-relink property was not checked;
- the CI contract was spread across several documentation locations.

This change turns that initial workflow into a clear and reproducible build-
integration baseline without expanding it into a general testing or
static-analysis pipeline.

## Scope

### Included

- `.github/workflows/ci.yml`
- `docs/development/continuous-integration.md`
- CI documentation in `docs/development/README.md`
- CI section in `docs/development/git-workflow.md`
- CI capability description in `docs/testing/validation-strategy.md`
- CI summary in the root `README.md`

### Out of scope

- Minishell source changes
- Makefile changes
- automated behavioural regression tests
- Norminette automation
- Valgrind automation
- file-descriptor automation
- static analysis
- coverage reporting
- runtime behaviour changes

## Validation

Local workflow-equivalent validation was performed before opening this pull
request.

### Build validation

```text
make fclean && make
PASS

expected ./minishell executable
PASS

second make
make: Nothing to be done for 'all'.

no-relink validation
PASS
```

### Repository validation

```text
Minishell source and Makefile unchanged: PASS
No out-of-scope automation added: PASS
git diff --check: PASS
```

### Documentation validation

```text
Files checked: 5
Local links: 50
Errors: 0
CI documentation audit: PASS
```

### Issue acceptance audit

```text
Changed files: 6
Errors: 0
Issue #42 acceptance audit: PASS
```

The remaining platform-specific validation is the actual GitHub Actions run on
the pull request using the configured Ubuntu 24.04 runner.

## Review notes

The workflow intentionally keeps the existing status-check identity:

```text
CI / build
```

The workflow name remains `CI` and the job identifier remains `build`.

A green `CI / build` result means that the maintained build-integration
requirements passed. It does not imply behavioural test coverage, memory
validation, FD validation, static analysis or coverage reporting.

Ubuntu 24.04 is the CI reference environment. It is not a declaration that
Minishell can only run on Ubuntu 24.04.

## Checklist

- [x] Linked issue is included
- [x] CI triggers are explicit
- [x] Build dependency is explicit
- [x] Repository permissions follow least privilege
- [x] Pull-request concurrency is handled
- [x] Build timeout is configured
- [x] Clean build is validated
- [x] Expected executable is validated
- [x] No-relink behaviour is validated
- [x] CI guarantees and limitations are documented
- [x] Testing and static-analysis work remain separate
- [x] No Minishell source behaviour changes are included
- [x] Local validation is documented above