### PR TITLE
ci: establish static analysis and quality checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,49 @@ jobs:
             echo "minishell was unexpectedly relinked"
             exit 1
           fi
+
+  quality:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install quality dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            clang \
+            libreadline-dev
+
+      - name: Clean Clang build
+        shell: bash
+        run: |
+          set -euo pipefail
+          make fclean
+          make CC=clang
+
+      - name: Verify Clang build artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -x ./minishell
+
+      - name: Verify Clang no relink
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          before="$(stat -c '%y' ./minishell)"
+          make CC=clang
+          after="$(stat -c '%y' ./minishell)"
+
+          if [ "$before" != "$after" ]; then
+            echo "Clang build unexpectedly relinked minishell"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -445,8 +445,14 @@ does not relink it.
 The CI baseline and its failure semantics are documented in
 [`docs/development/continuous-integration.md`](docs/development/continuous-integration.md).
 
+The workflow also provides an independent Clang compiler-diversity quality
+check through `CI / quality`.
+
+The quality-tool evaluation and rationale are documented in
+[`docs/development/static-analysis.md`](docs/development/static-analysis.md).
+
 The workflow does not currently provide an automated behavioural regression
-suite, resource checks, static analysis or coverage reporting.
+suite, resource checks, general static-analysis gates or coverage reporting.
 
 Original 42 evaluation preparation and project-era validation evidence remain
 preserved under
@@ -456,8 +462,8 @@ mandatory manual test matrix.
 Historical PASS results are evidence of the original project validation, not
 claims that the current baseline is automatically revalidated.
 
-Automated regression testing, static analysis and broader CI quality gates
-remain future modernization work.
+Automated regression testing, resource-oriented automation and any future
+general static-analysis gates remain separate modernization work.
 
 ## Current Scope and Limitations
 
@@ -544,7 +550,7 @@ The portfolio roadmap includes improving:
 
 - architecture documentation;
 - automated testing and CI;
-- static analysis and quality checks;
+- deeper static-analysis and quality auditing;
 - API documentation;
 - resource-ownership documentation;
 - regression testing;

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -16,7 +16,9 @@ For contributors and maintainers beginning from the repository root:
 - [`git-workflow.md`](git-workflow.md) documents the detailed Git and GitHub
   lifecycle;
 - [`continuous-integration.md`](continuous-integration.md) documents the
-  maintained GitHub Actions build baseline, its guarantees and its limitations.
+  maintained GitHub Actions baseline, its guarantees and its limitations;
+- [`static-analysis.md`](static-analysis.md) documents compiler-diversity
+  quality checks, evaluated static-analysis tools and the tooling rationale.
 
 ## Current Workflow
 
@@ -70,6 +72,10 @@ See:
 For the CI contract itself, see:
 
 [`continuous-integration.md`](continuous-integration.md)
+
+For compiler-quality and static-analysis decisions, see:
+
+[`static-analysis.md`](static-analysis.md)
 
 ## Repository Governance
 

--- a/docs/development/continuous-integration.md
+++ b/docs/development/continuous-integration.md
@@ -3,8 +3,9 @@
 This document describes the maintained continuous-integration baseline for the
 repository.
 
-The current GitHub Actions workflow provides build integration checks. It is
-deliberately narrower than a complete quality gate.
+The current GitHub Actions workflow provides reference build integration and
+compiler-diversity quality checks. It remains deliberately narrower than a
+complete behavioural, resource-safety or static-analysis gate.
 
 The authoritative workflow configuration is:
 
@@ -14,13 +15,15 @@ The authoritative workflow configuration is:
 
 The CI baseline answers a focused question:
 
-> Can the repository be checked out in the maintained CI environment and
-> produce the expected Minishell executable through a clean, stable build?
+> Can the repository be checked out in the maintained CI environment,
+> produce the expected Minishell executable through the reference build and
+> also compile cleanly through the selected independent compiler check?
 
-The workflow also checks one important Makefile invariant: rebuilding an
+Both maintained jobs check one important Makefile invariant: rebuilding an
 unchanged tree must not relink the final executable.
 
-The workflow does not currently claim behavioural test coverage.
+The workflow does not currently claim behavioural test coverage or a general
+static-analysis guarantee.
 
 ## When CI Runs
 
@@ -29,26 +32,27 @@ The workflow is triggered by:
 - pull requests;
 - pushes to `main`.
 
-A normal feature-branch push does not run this workflow by itself.
+An ordinary push to a feature branch does not trigger this workflow until a
+pull request exists.
 
-For the maintained contribution lifecycle, this means:
+The maintained flow is:
 
-```text
-feature branch push
-        |
-        v
-no CI run required yet
+    feature branch push
+            |
+            v
+    no CI run required yet
 
-pull request opened or updated
-        |
-        v
-CI / build
+    pull request opened or updated
+            |
+            v
+    CI / build
+    CI / quality
 
-squash merge to main
-        |
-        v
-CI / build
-```
+    squash merge to main
+            |
+            v
+    CI / build
+    CI / quality
 
 Pull-request runs that are superseded by newer commits are cancelled.
 
@@ -56,25 +60,27 @@ Push runs on `main` are not cancelled by that pull-request policy.
 
 ## Execution Environment
 
-The build job currently uses:
+Both maintained jobs use:
 
-```text
-ubuntu-24.04
-```
+    ubuntu-24.04
 
-The runner version is explicit rather than using `ubuntu-latest`.
+Using an explicit runner version avoids silently following the moving
+`ubuntu-latest` alias.
 
-This reduces accidental changes to the CI environment when GitHub advances the
-meaning of its `latest` runner alias.
+Ubuntu 24.04 is the maintained CI reference environment. It is not a claim
+that Minishell can only compile or run on Ubuntu 24.04.
 
-The workflow has a job timeout of:
+The reference `build` job uses the compiler selected by the repository
+Makefile through:
 
-```text
-10 minutes
-```
+    CC = cc
 
-A build that exceeds that limit fails rather than occupying a runner
-indefinitely.
+The `quality` job installs Clang and overrides the Make variable only for that
+CI invocation:
+
+    make CC=clang
+
+This does not modify the Makefile or replace the original compiler interface.
 
 ## Workflow Permissions
 
@@ -99,119 +105,100 @@ These settings keep the build workflow read-only at the repository level.
 
 ## Build Dependency
 
-The external system dependency required by the maintained build is:
+The reference build requires the Readline development package:
 
-```text
-libreadline-dev
-```
+    libreadline-dev
 
-The workflow installs it with:
+The quality job requires:
 
-```bash
-sudo apt-get update
-sudo apt-get install -y --no-install-recommends libreadline-dev
-```
+    clang
+    libreadline-dev
 
-GNU Readline is linked by the project Makefile through:
+The workflow installs these dependencies through the Ubuntu package manager
+with `--no-install-recommends`.
 
-```text
--lreadline
-```
+The project links against Readline through the existing Makefile.
 
-The repository's own `libft` is built from the checked-out source tree rather
-than installed as a system dependency.
+The local `libft` is built from repository source and is not installed as an
+external package.
 
 ## Build Pipeline
 
-The current `build` job performs the following checks.
+The workflow contains two independent jobs.
 
-### 1. Checkout Repository
+### Reference Build
 
-The repository is checked out using:
+`CI / build`:
 
-```text
-actions/checkout@v4
-```
+1. checks out the repository without persisting credentials;
+2. installs `libreadline-dev`;
+3. runs `make fclean`;
+4. runs the normal `make` reference build;
+5. verifies that `./minishell` exists and is executable;
+6. runs `make` again and verifies that the executable timestamp does not
+   change.
 
-No persisted Git credentials are required after checkout.
+The normal Makefile remains authoritative for the reference build.
 
-### 2. Install Build Dependencies
+### Compiler-Diversity Quality Build
 
-The workflow installs the GNU Readline development package required to compile
-and link Minishell.
+`CI / quality`:
 
-### 3. Clean Build
+1. checks out the repository without persisting credentials;
+2. installs Clang and `libreadline-dev`;
+3. runs `make fclean`;
+4. runs `make CC=clang`;
+5. verifies that `./minishell` exists and is executable;
+6. runs `make CC=clang` again and verifies that the executable timestamp does
+   not change.
 
-The workflow executes:
+The `CC=clang` value is a command-line Make override.
 
-```bash
-make fclean
-make
-```
+It does not change the repository's:
 
-Starting from `make fclean` makes the build check explicit even though GitHub
-Actions already provides a fresh checkout for each job.
+    CC = cc
 
-The build therefore validates that the project can be rebuilt from its own
-clean state rather than succeeding only because generated objects already
-exist.
+setting.
 
-### 4. Verify the Build Artifact
+Both jobs therefore exercise the same source tree and Makefile while using
+independent compiler paths.
 
-After compilation, the workflow checks:
-
-```bash
-test -x ./minishell
-```
-
-A successful compiler exit alone is not treated as sufficient if the expected
-executable is missing or is not executable.
-
-### 5. Verify No Relink
-
-The workflow records the modification timestamp of `./minishell`, executes:
-
-```bash
-make
-```
-
-again and compares the timestamp afterward.
-
-If the timestamp changes, CI fails.
-
-This checks that an unchanged repository does not unnecessarily relink the
-final executable.
-
-The local discovery audit for the CI workstream confirmed that the current
-Makefile already satisfies this property:
-
-```text
-make: Nothing to be done for 'all'.
-```
-
-The workflow therefore validates an existing Makefile invariant. It does not
-modify the Makefile to create one.
+The second build in each job validates the existing no-relink Makefile
+invariant.
 
 ## Failure Semantics
 
-A failed `CI / build` check means that at least one maintained build-integration
-requirement was not satisfied.
+A failed `CI / build` check means that at least one reference
+build-integration requirement was not satisfied.
 
 Examples include:
 
-- the dependency installation failed;
-- `make fclean` failed;
-- the clean build failed;
-- the expected `minishell` executable was not produced;
-- the executable was not executable;
-- an unchanged second `make` relinked the executable;
-- the build exceeded the configured timeout;
-- another workflow step terminated unsuccessfully.
+- dependency installation failure;
+- `make fclean` failure;
+- reference compilation failure;
+- failure to produce an executable `./minishell`;
+- unexpected relinking during the second `make`;
+- job timeout;
+- another unsuccessful workflow step.
 
-A failed build check does not identify every possible runtime defect.
+A failed `CI / quality` check means that at least one maintained
+compiler-diversity requirement was not satisfied.
 
-Conversely, a successful build check does not prove complete Minishell
-correctness.
+Examples include:
+
+- Clang installation failure;
+- `make fclean` failure;
+- compilation failure under `make CC=clang`;
+- a Clang diagnostic promoted to an error by `-Werror`;
+- failure to produce an executable `./minishell`;
+- unexpected relinking during the second `make CC=clang`;
+- job timeout;
+- another unsuccessful workflow step.
+
+Neither failed check identifies every possible runtime defect.
+
+Likewise, successful checks do not imply behavioural correctness, resource
+safety or general static-analysis cleanliness.
 
 ## Concurrency Behaviour
 
@@ -237,18 +224,28 @@ condition is false.
 
 ## What CI Currently Guarantees
 
-A successful current CI run provides evidence that:
+A successful current CI run provides two complementary build signals.
 
-- the repository can be checked out by GitHub Actions;
-- the declared build dependency can be installed;
-- the project can complete a clean build on Ubuntu 24.04;
-- the expected `minishell` executable is produced;
-- the executable is marked executable;
-- an unchanged second `make` does not relink the executable.
+`CI / build` confirms that:
 
-These are build-integration guarantees only.
+- the repository can perform a clean reference build through `CC = cc`;
+- the expected Minishell executable is produced;
+- an unchanged second build does not relink the executable.
 
-## What CI Does Not Currently Guarantee
+`CI / quality` confirms that:
+
+- the same repository and Makefile compile cleanly through Clang;
+- the existing `-Wall -Wextra -Werror` diagnostics remain clean under that
+  compiler;
+- the expected Minishell executable is produced;
+- an unchanged second Clang build does not relink the executable.
+
+These are build-integration and compiler-diversity guarantees.
+
+They are deliberately narrower than behavioural testing, resource validation
+or general static analysis.
+
+## What the CI Baseline Does Not Guarantee
 
 The current workflow does not run:
 
@@ -258,10 +255,19 @@ The current workflow does not run:
 - Norminette;
 - Valgrind;
 - file-descriptor leak checks;
-- static analysis;
+- GCC `-fanalyzer`;
+- the Clang Static Analyzer;
+- `cppcheck`;
+- `clang-tidy`;
 - code-coverage reporting.
 
-Those capabilities must not be inferred from a green `CI / build` result.
+Those capabilities must not be inferred from a green `CI / build` or
+`CI / quality` result.
+
+The maintained compiler-quality and static-analysis evaluation is documented
+in:
+
+[`static-analysis.md`](static-analysis.md)
 
 The maintained testing model is documented under:
 
@@ -274,32 +280,44 @@ In particular:
 - [`../testing/manual-validation.md`](../testing/manual-validation.md)
   defines reproducible manual validation procedures.
 
-## Relationship to Future Quality Automation
+## Relationship to Quality Automation
 
-This CI baseline intentionally provides a stable foundation rather than
-collecting every future quality check into one workstream.
+The CI baseline now contains two maintained jobs:
 
-Separate modernization work can later introduce:
+    CI / build
+    CI / quality
 
-- automated regression testing;
-- static analysis and other quality checks;
-- additional CI jobs where they provide demonstrated value.
+`CI / build` preserves the reference Makefile build through `CC = cc`.
 
-When those capabilities are actually implemented, this document and the
-testing documentation should be updated to describe the expanded CI contract.
+`CI / quality` performs an independent Clang build through a command-line
+`CC=clang` override while preserving the same source and Makefile.
+
+The quality job provides compiler diversity. It is not the Clang Static
+Analyzer and must not be presented as general static-analysis coverage.
+
+The tooling evaluation and selection rationale are documented in:
+
+[`static-analysis.md`](static-analysis.md)
+
+Separate modernization work can still introduce automated regression testing,
+resource-oriented checks or additional analyzer gates where they provide
+demonstrated value.
 
 ## Relationship to Branch Protection
 
 The maintained repository uses pull requests and protected `main` governance.
 
-The workflow's stable identity remains:
+The reference build keeps the stable status-check identity:
 
-```text
-CI / build
-```
+    CI / build
 
-Keeping the workflow name `CI` and job identifier `build` avoids unnecessarily
-changing the status-check identity while the baseline itself is improved.
+The maintained compiler-diversity check adds:
+
+    CI / quality
+
+Keeping the workflow name `CI` and the existing `build` job identifier
+preserves the reference build identity while allowing quality checks to remain
+a distinct concern.
 
 Repository-governance details are documented in:
 
@@ -307,21 +325,29 @@ Repository-governance details are documented in:
 
 ## Local Equivalent
 
-The central build behaviour can be reproduced locally with:
+The reference build can be reproduced locally with:
 
-```bash
-make fclean
-make
+    make fclean
+    make
+    test -x ./minishell
 
-test -x ./minishell
+The compiler-diversity quality build can be reproduced with:
 
-before="$(stat -c '%y' ./minishell)"
-make
-after="$(stat -c '%y' ./minishell)"
+    make fclean
+    make CC=clang
+    test -x ./minishell
 
-test "$before" = "$after"
-```
+The no-relink property can be checked for the reference build by recording the
+executable timestamp, running `make` again and confirming that the timestamp
+does not change.
 
-The GitHub-specific parts, including runner selection, permissions,
-pull-request concurrency and status-check behaviour, require an actual GitHub
-Actions run for final validation.
+The equivalent quality check uses:
+
+    make CC=clang
+
+for the second build.
+
+Local reproduction validates the build logic.
+
+The actual GitHub Actions runner, workflow permissions, concurrency behaviour
+and status checks are validated by the pull-request workflow itself.

--- a/docs/development/git-workflow.md
+++ b/docs/development/git-workflow.md
@@ -462,23 +462,38 @@ The workflow runs:
 - for pull requests;
 - for pushes to `main`.
 
-The current `CI / build` job uses Ubuntu 24.04, installs the Readline
-development dependency and validates:
+The current workflow contains two maintained jobs.
 
-- a clean `make fclean && make` build;
+`CI / build` uses Ubuntu 24.04 and validates:
+
+- a clean `make fclean && make` reference build;
 - creation of the executable `./minishell`;
 - no unnecessary relink when `make` is immediately repeated.
 
-The workflow uses explicit read-only repository permissions, a job timeout and
+`CI / quality` uses the same runner baseline and validates:
+
+- a clean `make fclean && make CC=clang` compiler-diversity build;
+- creation of the executable `./minishell`;
+- no unnecessary relink when `make CC=clang` is immediately repeated.
+
+The workflow uses explicit read-only repository permissions, job timeouts and
 pull-request concurrency cancellation for superseded runs.
 
-A successful `CI / build` result is evidence that these build-integration
-requirements passed.
+A successful `CI / build` result is evidence that the reference
+build-integration requirements passed.
 
-It is not evidence of complete behavioural correctness.
+A successful `CI / quality` result is evidence that the project also compiles
+cleanly through the maintained Clang quality check.
 
-Automated regression tests, static analysis, Valgrind, FD checks and broader
-quality automation belong to separate modernization workstreams.
+Neither result is evidence of complete behavioural correctness, memory safety,
+file-descriptor safety or general static-analysis coverage.
+
+The quality-tool evaluation and current selection rationale are documented in:
+
+[`static-analysis.md`](static-analysis.md)
+
+Automated regression tests, Valgrind, FD checks and additional analyzer gates
+remain separate concerns.
 
 Before merge, confirm that the available checks have completed successfully.
 

--- a/docs/development/static-analysis.md
+++ b/docs/development/static-analysis.md
@@ -248,6 +248,62 @@ been demonstrated.
 
 It is not part of the current baseline.
 
+## Investigative Tool Reproduction
+
+The investigative checks evaluated during issue #44 can also be reproduced
+locally.
+
+### Norminette
+
+The maintained C source and headers were checked with:
+
+    norminette include src libft
+
+The audited result reported all 71 files as `OK!` together with two
+`GLOBAL_VAR_DETECTED` notices for the deliberate signal-state global.
+
+Because those notices cause a non-zero command status, the raw exit code is
+not currently suitable as a hard CI gate.
+
+### GCC `-fanalyzer`
+
+The GCC analyzer discovery checked each C translation unit independently:
+
+    tmp_dir="$(mktemp -d)"
+
+    while IFS= read -r file; do
+        gcc -Wall -Wextra -Werror -fanalyzer             -Iinclude -Ilibft             -c "$file"             -o "$tmp_dir/$(basename "$file").o"
+    done < <(
+        find src libft -type f -name '*.c' -print | sort
+    )
+
+    rm -rf "$tmp_dir"
+
+The findings require domain-aware classification and are not currently used as
+a hard CI gate.
+
+### Clang Static Analyzer
+
+The Clang Static Analyzer discovery checked each C translation unit
+independently:
+
+    while IFS= read -r file; do
+        clang --analyze             -Wall -Wextra -Werror             -Iinclude -Ilibft             "$file"
+    done < <(
+        find src libft -type f -name '*.c' -print | sort
+    )
+
+The audited invocation can generate `.plist` analyzer artefacts in the working
+directory.
+
+Those generated files are not repository content and can be removed after the
+investigation with:
+
+    find . -maxdepth 1 -type f -name '*.plist' -delete
+
+Analyzer output and exit-status semantics must be handled deliberately before
+this check could become an automated CI gate.
+
 ## Failure Semantics
 
 `CI / quality` fails when:

--- a/docs/development/static-analysis.md
+++ b/docs/development/static-analysis.md
@@ -1,0 +1,349 @@
+# Static Analysis and Quality Checks
+
+This document describes the maintained compiler-quality baseline, the
+static-analysis tools evaluated for Minishell and the reasoning behind the
+checks selected for continuous integration.
+
+The current implementation deliberately separates compiler diagnostics from
+static analysis.
+
+The authoritative CI workflow is:
+
+[`../../.github/workflows/ci.yml`](../../.github/workflows/ci.yml)
+
+## Purpose
+
+The quality baseline answers a focused question:
+
+> Does the maintained source compile cleanly through an independent C compiler
+> while preserving the same build invariants as the reference build?
+
+Different compilers can expose different diagnostics even when they are given
+equivalent warning flags.
+
+The current automated quality check does not claim that the program is free of
+runtime defects, memory problems, file-descriptor leaks or behavioural bugs.
+
+## Existing Compiler Baseline
+
+The project Makefile preserves the original compiler interface:
+
+    CC = cc
+    CFLAGS = -Wall -Wextra -Werror
+
+On the audited Ubuntu 24.04 development environment, `cc` resolves to GCC
+13.3.
+
+The maintained reference build therefore remains:
+
+    make
+
+The repository does not change `CC = cc` to GCC or Clang as part of portfolio
+modernization.
+
+## Automated Compiler Diversity
+
+The CI workflow contains a separate `quality` job.
+
+Its build is executed with:
+
+    make fclean
+    make CC=clang
+
+The command-line `CC=clang` value is a temporary Make variable override.
+
+It does not modify the Makefile and does not change the compiler interface
+preserved from the original 42 project.
+
+The quality job validates:
+
+1. a clean Clang build using the existing Makefile;
+2. creation of the expected `./minishell` executable;
+3. no unnecessary relink when `make CC=clang` is immediately repeated.
+
+The workflow uses the same repository warning flags:
+
+    -Wall -Wextra -Werror
+
+The resulting GitHub status-check identity is:
+
+    CI / quality
+
+## Why Compiler Diversity Was Selected
+
+The audited repository contained approximately:
+
+    69 C translation units
+    2 headers
+    3650 lines of C source
+
+During the issue #44 discovery audit, all 69 C translation units compiled
+successfully with Clang using:
+
+    -Wall -Wextra -Werror
+
+The observed result was:
+
+    69 translation units checked
+    0 translation units failed
+    0 compiler diagnostics
+
+The complete project also passed:
+
+    make CC=clang
+    expected ./minishell artifact
+    second make with no relink
+
+This provided useful independent compiler signal while requiring:
+
+- no source changes;
+- no Makefile changes;
+- no compilation database;
+- no analyzer-specific suppression configuration;
+- no additional project-level build system.
+
+For the maintained CI baseline, this signal-to-complexity ratio was preferred
+over immediately introducing a heavier static-analysis gate.
+
+## Candidate Evaluation
+
+Several quality mechanisms were evaluated before selecting the current
+automated check.
+
+### Compiler Warnings
+
+The existing build already uses:
+
+    -Wall -Wextra -Werror
+
+This remains the primary compiler-diagnostic baseline.
+
+Compiler warnings are valuable but do not provide complete static analysis.
+
+### Norminette
+
+Norminette remains relevant because Minishell originated as a 42 project and
+the historical source follows 42-style constraints.
+
+The discovery audit used Norminette 3.3.59 across the maintained C source and
+headers.
+
+Observed result:
+
+    71 files reported OK
+    0 Error! diagnostics
+    2 GLOBAL_VAR_DETECTED notices
+
+The notices correspond to the global signal state:
+
+    extern volatile sig_atomic_t g_signal;
+    volatile sig_atomic_t g_signal;
+
+This is a deliberate signal-handling design choice.
+
+Despite all files reporting `OK!`, the command returned exit status 1 because
+of the notices.
+
+For that reason, raw Norminette exit status is not currently used as an
+automated hard CI gate.
+
+Norminette remains useful as 42-specific manual validation where appropriate.
+
+### GCC `-fanalyzer`
+
+GCC's path-sensitive analyzer was evaluated using the existing source and
+include structure.
+
+The discovery run checked all 69 C translation units.
+
+Four translation units failed under `-Werror`, producing diagnostics centred
+on file-descriptor ownership and process control.
+
+The findings included:
+
+- an apparent double close in the heredoc child/parent path;
+- alleged descriptor leaks after `dup2()` in pipeline setup;
+- alleged descriptor leaks after `dup2()` during redirection;
+- alleged descriptor leaks while restoring standard input and output.
+
+The heredoc diagnostic was investigated against the implementation.
+
+The analyzer modeled a path in which `heredoc_child()` could return to
+`exe_heredoc_setup()` and continue into the parent path.
+
+The actual child termination helper ultimately executes:
+
+    exit(status);
+
+Therefore the analyzed child path does not return in runtime execution.
+
+The `dup2()` findings also reflect descriptor ownership that is intentional in
+a shell. After duplication to `STDIN_FILENO` or `STDOUT_FILENO`, that standard
+descriptor is expected to remain open for subsequent command execution.
+
+Because the current findings require domain-aware interpretation and would make
+the workflow fail without appropriate classification or suppression policy,
+GCC `-fanalyzer` is retained as an investigative tool rather than a hard CI
+gate.
+
+### Clang Static Analyzer
+
+The Clang Static Analyzer was also evaluated across all 69 C translation
+units.
+
+Observed result:
+
+    69 translation units checked
+    0 command failures
+    1 analyzer diagnostic
+
+The diagnostic concerned `libft/ft_memcpy.c` and a possible null destination
+dereference.
+
+The maintained call sites examined during the audit provide allocated
+destinations before copying, and the normal `memcpy` contract already requires
+valid pointer arguments when bytes are copied.
+
+The diagnostic was therefore not demonstrated to represent a current
+Minishell runtime defect during this workstream.
+
+The analyzer also introduced additional operational considerations:
+
+- analyzer output files were generated unless output handling was configured;
+- warning output did not automatically produce the desired CI failure
+  semantics;
+- analyzer findings require explicit classification policy.
+
+It is retained as an investigative tool rather than an automated hard gate.
+
+### `cppcheck`
+
+`cppcheck` was considered as an additional independent C static analyzer.
+
+It was not already present in the audited development environment.
+
+The existing compiler and analyzer evaluation produced enough information to
+select a useful low-complexity CI check without introducing another dependency.
+
+`cppcheck` is therefore not part of the current baseline.
+
+It can be reconsidered if future source audits demonstrate a concrete need for
+additional analyzer coverage.
+
+### `clang-tidy`
+
+`clang-tidy` was also considered.
+
+The repository currently has no:
+
+    compile_commands.json
+    .clang-tidy
+    CMakeLists.txt
+
+and the audited environment did not contain Bear.
+
+Introducing `clang-tidy` would therefore add tool installation, configuration
+and compilation-database considerations before its value for this codebase had
+been demonstrated.
+
+It is not part of the current baseline.
+
+## Failure Semantics
+
+`CI / quality` fails when:
+
+- required CI dependencies cannot be installed;
+- `make fclean` fails;
+- the project does not compile successfully with `CC=clang`;
+- compiler diagnostics promoted by `-Werror` cause compilation failure;
+- the expected `./minishell` executable is not produced;
+- an unchanged second `make CC=clang` unexpectedly relinks the executable;
+- the job exceeds its configured timeout;
+- any workflow step exits unsuccessfully.
+
+A successful `CI / quality` result means that the repository satisfied these
+compiler-diversity and build-integration requirements.
+
+It does not mean that separate static analyzers produced no findings.
+
+## Local Reproduction
+
+The automated quality check can be reproduced locally with:
+
+    make fclean
+    make CC=clang
+    test -x ./minishell
+
+    before="$(stat -c '%y' ./minishell)"
+    make CC=clang
+    after="$(stat -c '%y' ./minishell)"
+
+    test "$before" = "$after"
+
+The normal reference build remains:
+
+    make fclean
+    make
+
+## Guarantees
+
+A successful current CI run provides two complementary build signals:
+
+    CI / build
+        reference Makefile build through CC = cc
+
+    CI / quality
+        independent Clang build through CC override
+
+Both use the repository's existing warning flags and validate the expected
+build artifact and no-relink behaviour.
+
+## What the Quality Baseline Does Not Guarantee
+
+A green `CI / quality` result does not prove:
+
+- behavioural correctness;
+- shell grammar correctness;
+- memory safety;
+- file-descriptor leak freedom;
+- signal correctness;
+- Norminette compliance;
+- absence of GCC `-fanalyzer` findings;
+- absence of Clang Static Analyzer findings;
+- absence of defects detectable by other static-analysis tools;
+- regression coverage;
+- code coverage.
+
+These concerns require their own validation mechanisms.
+
+## Relationship to Testing
+
+Compiler diagnostics and static analysis are complementary to testing rather
+than replacements for it.
+
+The maintained testing model is documented in:
+
+[`../testing/`](../testing/)
+
+In particular:
+
+- [`../testing/validation-strategy.md`](../testing/validation-strategy.md)
+  defines the validation layers and current automation boundaries;
+- [`../testing/manual-validation.md`](../testing/manual-validation.md)
+  defines reproducible runtime and resource-oriented manual checks.
+
+## Future Evaluation
+
+Static-analysis tools can be reconsidered as the repository evolves.
+
+A future change should only promote an analyzer to a hard CI gate when:
+
+- its findings provide demonstrated value for the maintained codebase;
+- known false positives can be handled without hiding important defect classes;
+- local and CI execution are reproducible;
+- failure semantics are explicit;
+- suppressions or exclusions are documented;
+- the maintenance cost remains proportional to the benefit.
+
+The later code-quality audit may use the investigated analyzers as diagnostic
+tools without automatically making them permanent CI gates.

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -16,7 +16,8 @@ The maintained repository currently has:
 | Capability | Current state |
 | --- | --- |
 | Local build validation | Available through `make` |
-| Pull-request build validation | Automated through GitHub Actions |
+| Pull-request reference build validation | Automated through `CI / build` |
+| Compiler-diversity quality validation | Automated through `CI / quality` with Clang |
 | Manual behavioural validation | Maintained practice |
 | Memory validation | Manual, using Valgrind where relevant |
 | File-descriptor validation | Manual, using Valgrind `--track-fds=yes` where relevant |
@@ -25,9 +26,10 @@ The maintained repository currently has:
 | Static-analysis automation | Not implemented |
 | Coverage reporting | Not implemented |
 
-A successful CI run currently demonstrates that the project builds in the CI
+A successful CI run currently demonstrates that the project passes the
+reference build and maintained Clang compiler-diversity checks in the CI
 environment. It does not demonstrate complete behavioural correctness,
-resource safety or regression coverage.
+resource safety, static-analysis cleanliness or regression coverage.
 
 ## Maintained Documentation
 

--- a/docs/testing/validation-strategy.md
+++ b/docs/testing/validation-strategy.md
@@ -201,11 +201,20 @@ The current `CI / build` job:
 4. verifies that `./minishell` is executable;
 5. verifies that an unchanged second `make` does not relink the executable.
 
-The workflow also defines explicit read-only repository permissions, a
-10-minute job timeout and cancellation of superseded pull-request runs.
+The current `CI / quality` job:
 
-Therefore, the current CI provides automated build-integration validation
-only.
+1. checks out the repository;
+2. installs Clang and `libreadline-dev`;
+3. performs `make fclean && make CC=clang`;
+4. verifies that `./minishell` is executable;
+5. verifies that an unchanged second `make CC=clang` does not relink the
+   executable.
+
+The workflow also defines explicit read-only repository permissions,
+10-minute job timeouts and cancellation of superseded pull-request runs.
+
+The current CI therefore provides both reference build integration and
+compiler-diversity validation.
 
 It does not currently run:
 
@@ -214,8 +223,15 @@ It does not currently run:
 - Valgrind;
 - file-descriptor checks;
 - signal-interaction tests;
-- static analysis;
+- GCC `-fanalyzer`;
+- the Clang Static Analyzer;
+- `cppcheck`;
+- `clang-tidy`;
 - coverage reporting.
+
+The compiler-quality and analyzer evaluation is documented in:
+
+[`../development/static-analysis.md`](../development/static-analysis.md)
 
 These limitations should remain visible until the corresponding automation is
 actually implemented.
@@ -310,8 +326,12 @@ Future testing work may consider:
 - automated resource checks where results can be interpreted reliably;
 - coverage reporting where it provides useful engineering information.
 
-Static analysis and broader CI quality gates are separate modernization
-workstreams.
+Compiler-diversity quality validation is now automated through
+`CI / quality`.
+
+General static-analysis gates remain separate from compiler diagnostics and
+should only be introduced where the analyzer provides demonstrated,
+maintainable signal.
 
 Testing automation should be added as executable infrastructure, not inferred
 from historical Markdown test matrices.


### PR DESCRIPTION
## Linked issue

Closes #44

## Summary

Establish a deliberate static-analysis and compiler-quality baseline for the
maintained Minishell repository.

This pull request:

- preserves the original Makefile compiler interface with `CC = cc`;
- adds a separate `CI / quality` job using Clang through a command-line
  `CC=clang` override;
- validates a clean Clang build using the existing `-Wall -Wextra -Werror`
  flags;
- verifies the expected `./minishell` executable;
- verifies that an unchanged second Clang build does not relink;
- evaluates Norminette, GCC `-fanalyzer`, the Clang Static Analyzer,
  `cppcheck` and `clang-tidy`;
- documents why compiler diversity was selected for automated CI;
- preserves reproducible commands for the investigated analyzers;
- documents quality-check guarantees, failure semantics and limitations.

## Tooling decision

The maintained automated baseline now separates the reference build from an
independent compiler-quality check.

    CI / build
        make
        CC = cc

    CI / quality
        make CC=clang

The Makefile remains unchanged.

Clang was selected as the additional automated quality check because the full
project compiled cleanly with the existing warning flags and required no
source changes, Makefile changes, compilation database or analyzer-specific
suppression policy.

The following tools were evaluated but were not promoted to hard CI gates:

- Norminette, because all 71 files reported `OK!` but the deliberate global
  signal state produced notices and a non-zero raw exit status;
- GCC `-fanalyzer`, because current findings require domain-aware
  interpretation around process and file-descriptor ownership;
- the Clang Static Analyzer, because its current finding and execution
  semantics require explicit classification and output handling;
- `cppcheck`, because an additional dependency was not justified by a
  demonstrated current need;
- `clang-tidy`, because its configuration and compilation-database cost was
  not justified by demonstrated value for the current codebase.

The investigated analyzers remain useful diagnostic tools and their local
reproduction commands are documented.

## Scope

Included:

- GitHub Actions compiler-diversity quality job;
- compiler and static-analysis tooling evaluation;
- documented tooling-selection rationale;
- failure semantics;
- local reproduction instructions;
- CI and testing documentation alignment.

Out of scope:

- Minishell runtime behaviour changes;
- source-code refactoring;
- Makefile changes;
- automated behavioural regression tests;
- Valgrind automation;
- file-descriptor automation;
- coverage reporting;
- automatically fixing analyzer findings;
- introducing analyzer suppressions solely to obtain a green CI result.

## Validation

Repository acceptance audit:

    Changed files: 8
    Docs checked: 7
    Local links: 71
    Errors: 0
    Issue #44 acceptance audit: PASS

Reference build:

    make fclean
    make
    expected ./minishell artifact: PASS
    second make / no relink: PASS

Compiler-diversity quality build:

    make fclean
    make CC=clang
    expected ./minishell artifact: PASS
    second make CC=clang / no relink: PASS

Repository scope:

    source unchanged: PASS
    Makefile unchanged: PASS
    git diff --check: PASS
    working tree clean: PASS

## Review notes

The original project compiler interface remains:

    CC = cc
    CFLAGS = -Wall -Wextra -Werror

`CC=clang` is only a command-line Make override used by the separate quality
job. It does not modify the original build configuration.

`CI / quality` is a compiler-diversity check. It is not the Clang Static
Analyzer and does not claim general static-analysis coverage.

A green quality result does not prove behavioural correctness, memory safety,
file-descriptor safety, signal correctness, Norminette compliance or absence
of findings from dedicated static analyzers.

The existing status check remains:

    CI / build

and this pull request adds:

    CI / quality

## Checklist

- [x] Existing compiler and quality checks audited
- [x] Historical Norminette role assessed
- [x] Static-analysis candidates compared before selection
- [x] Selected tooling rationale documented
- [x] Added quality check provides independent compiler signal
- [x] Local execution is reproducible
- [x] Selected quality check added to CI
- [x] Failure semantics documented
- [x] Analyzer findings and limitations documented
- [x] Quality checks are not presented as behavioural coverage
- [x] Testing and resource validation remain separate concerns
- [x] Documentation reflects the resulting automation
- [x] No Minishell source behaviour changes introduced