### PR TITLE
docs(api): establish Doxygen and API documentation

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1,0 +1,46 @@
+# Minishell API documentation
+# Generated documentation is written under build/ and is not versioned.
+
+PROJECT_NAME           = "42 Minishell"
+PROJECT_BRIEF          = "Maintained API reference for the Minishell project"
+
+OUTPUT_DIRECTORY       = build/docs/doxygen
+
+OPTIMIZE_OUTPUT_FOR_C  = YES
+TYPEDEF_HIDES_STRUCT   = YES
+
+INPUT                  = include/minishell.h \
+                         libft/libft.h \
+                         docs/development/api-documentation.md
+
+FILE_PATTERNS          = *.h \
+                         *.md
+
+RECURSIVE              = NO
+
+EXTRACT_ALL            = NO
+EXTRACT_STATIC         = NO
+
+HIDE_UNDOC_MEMBERS     = YES
+HIDE_UNDOC_CLASSES     = YES
+
+JAVADOC_AUTOBRIEF      = YES
+MARKDOWN_SUPPORT       = YES
+USE_MDFILE_AS_MAINPAGE = docs/development/api-documentation.md
+
+SOURCE_BROWSER         = NO
+INLINE_SOURCES         = NO
+
+WARNINGS               = YES
+WARN_IF_UNDOCUMENTED   = YES
+WARN_IF_DOC_ERROR      = YES
+WARN_NO_PARAMDOC       = YES
+WARN_AS_ERROR          = NO
+
+GENERATE_HTML          = YES
+GENERATE_LATEX         = NO
+
+GENERATE_TREEVIEW      = YES
+SEARCHENGINE           = YES
+
+HAVE_DOT               = NO

--- a/README.md
+++ b/README.md
@@ -496,19 +496,25 @@ code as it exists rather than implying functionality that is not present.
 
 Additional project material lives under [`docs/`](docs/).
 
-The repository currently includes:
+The maintained documentation includes:
 
-- architecture and design notes;
-- development decisions;
-- planning material;
-- project-management conventions;
-- evaluation preparation;
+- architecture and engineering decision records;
+- testing and validation strategy;
+- contribution, CI and quality-tooling guidance;
+- API and resource-ownership documentation;
+- historical project and evaluation material;
 - the original project subject.
 
-Some architecture documents were created during development and describe the
-intended design rather than every detail of the final implementation. They are
-being reconciled with the final code as part of the repository modernization
-initiative.
+The maintained API-documentation strategy is defined in
+[`docs/development/api-documentation.md`](docs/development/api-documentation.md).
+
+A repository-controlled [`Doxyfile`](Doxyfile) generates a local HTML reference
+for the curated Minishell and Libft API boundary. Generated output remains
+under `build/` and is not versioned.
+
+Hand-written architecture documentation remains authoritative for system-level
+design. Doxygen supplements it with data-model, interface, ownership and
+side-effect contracts.
 
 ## Contributing
 
@@ -546,14 +552,15 @@ Repository modernization is tracked through
 
 ## Future Evolution
 
-The portfolio roadmap includes improving:
+Architecture documentation, continuous integration, quality-tooling guidance
+and the maintained API/resource-ownership baseline are now established as part
+of the repository modernization.
 
-- architecture documentation;
-- automated testing and CI;
-- deeper static-analysis and quality auditing;
-- API documentation;
-- resource-ownership documentation;
-- regression testing;
+The remaining portfolio roadmap includes:
+
+- deeper static-analysis and code-quality auditing;
+- broader automated regression testing;
+- evolution and release strategy for post-baseline work;
 - additional technical exploration beyond the original 42 scope.
 
 Future extensions will remain distinguishable from the original 42

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -19,6 +19,8 @@ For contributors and maintainers beginning from the repository root:
   maintained GitHub Actions baseline, its guarantees and its limitations;
 - [`static-analysis.md`](static-analysis.md) documents compiler-diversity
   quality checks, evaluated static-analysis tools and the tooling rationale.
+- [`api-documentation.md`](api-documentation.md) defines the maintained
+  API-documentation boundary, documentation conventions and Doxygen strategy.
 
 ## Current Workflow
 

--- a/docs/development/api-documentation.md
+++ b/docs/development/api-documentation.md
@@ -250,6 +250,50 @@ The repository should contain:
 The generated HTML or other output should remain local unless a later
 workstream deliberately introduces hosted documentation.
 
+## Local Generation
+
+The maintained API reference requires Doxygen.
+
+On Ubuntu, the required package can be installed with:
+
+    sudo apt install doxygen
+
+The configuration is stored in the repository root as:
+
+    Doxyfile
+
+Generate the documentation from the repository root with:
+
+    mkdir -p build/docs/doxygen
+    doxygen Doxyfile
+
+Doxygen writes the HTML reference to:
+
+    build/docs/doxygen/html/
+
+The entry point is:
+
+    build/docs/doxygen/html/index.html
+
+The repository already ignores `build/`, so generated documentation remains a
+local build artefact and must not be committed.
+
+The output directory is created explicitly because the audited Doxygen 1.9.8
+installation does not create the complete nested `build/docs/doxygen`
+directory hierarchy when its parent directories do not yet exist.
+
+The maintained configuration deliberately uses:
+
+    EXTRACT_ALL = NO
+    EXTRACT_STATIC = NO
+
+This keeps generated documentation aligned with the selective API boundary
+rather than automatically treating implementation details as public
+interfaces.
+
+Documentation generation is independent from the historical project Makefile.
+No `make docs` target is required by the current baseline.
+
 ## Relationship to Architecture Documentation
 
 Generated API documentation answers questions such as:

--- a/docs/development/api-documentation.md
+++ b/docs/development/api-documentation.md
@@ -208,19 +208,40 @@ The configuration should therefore:
 - remain lightweight enough for contributors to understand without a separate
   documentation build system.
 
-The initial documentation source boundary should focus on the maintained
-headers rather than presenting every implementation file as public API.
+The maintained documentation source boundary focuses on the repository's
+interface headers rather than presenting every implementation file as public
+API.
 
-## Existing Libft Documentation
+The generated API currently publishes:
 
-`libft/libft.h` already contains Doxygen-style documentation for its utility
-functions.
+- `include/minishell.h`, containing the curated Minishell data model and
+  selected cross-module contracts;
+- `libft/libft.h`, containing the documented utility API used by Minishell;
+- this document, used as the generated documentation main page.
 
-That documentation should be preserved and evaluated for consistency with the
-repository-wide convention.
+Both maintained headers include Doxygen `@file` documentation.
 
-The current workstream does not require rewriting correct Libft comments merely
-to make their wording uniform.
+With `EXTRACT_ALL = NO`, the audited Doxygen 1.9.8 configuration did not
+publish documented global functions, variables, enums and typedefs as file or
+global API pages until their containing headers were documented with `@file`.
+
+The `@file` declarations are therefore part of the maintained publication
+boundary rather than decorative file comments.
+
+## Libft Utility API
+
+`libft/libft.h` already contained useful Doxygen-style contracts for the
+bundled utility functions before the maintained documentation baseline was
+introduced.
+
+Those existing contracts are preserved rather than mechanically rewritten for
+wording consistency.
+
+The header is now an explicit documented Doxygen file and its documented
+functions are published alongside the Minishell API.
+
+This keeps useful Libft contracts discoverable while avoiding unnecessary
+documentation churn in working utility code.
 
 ## Historical 42 Headers
 

--- a/docs/development/api-documentation.md
+++ b/docs/development/api-documentation.md
@@ -1,0 +1,272 @@
+# API Documentation Strategy
+
+This document defines the maintained API-documentation boundary for Minishell
+and the role that Doxygen plays within the repository.
+
+## Purpose
+
+The goal of API documentation is to make meaningful contracts, shared data
+structures, ownership rules and subsystem boundaries easier to understand.
+
+It is not intended to mechanically document every function or implementation
+detail.
+
+The hand-written architecture documentation remains authoritative for
+system-level design.
+
+Doxygen provides a navigable reference for selected interfaces.
+
+## Documentation Boundary
+
+The maintained Doxygen boundary is primarily defined by:
+
+    include/minishell.h
+    libft/libft.h
+
+The central Minishell header contains interfaces shared between the program's
+session, scanner, grammar, expansion, execution, builtin, state, signal and
+support subsystems.
+
+The Libft header already contains Doxygen-style documentation for its utility
+interface.
+
+Implementation files under `src/` and `libft/` remain the source of function
+definitions, but implementation-local helpers are not part of the documented
+API by default.
+
+## Core Data Model
+
+The following types form the shared data model and should be documented:
+
+- `t_toktype`
+- `t_err`
+- `t_token`
+- `t_redir`
+- `t_cmd`
+- `t_shell`
+
+These types cross subsystem boundaries and represent the principal vocabulary
+used to move shell state, tokens, commands, redirections and errors through
+the runtime pipeline.
+
+The following structures are subsystem-local implementation details and should
+not normally be exposed as part of the maintained API reference:
+
+- `t_tokctx`
+- `t_child_ctx`
+- `t_pipe_state`
+
+They may still receive targeted comments where a non-obvious invariant or
+ownership rule needs explanation.
+
+## Global Signal State
+
+The declaration:
+
+    extern volatile sig_atomic_t g_signal;
+
+is part of the documented cross-module contract.
+
+The documentation should explain its role as signal state shared between the
+signal handlers and the session or execution logic.
+
+Documentation must not imply that the variable is a general-purpose global
+state mechanism.
+
+## Cross-Module Interfaces
+
+Functions deserve API documentation when their contract is relevant outside
+the subsystem that defines them.
+
+Current cross-module candidates include the following categories.
+
+### Runtime pipeline
+
+- `ses_loop`
+- `scn_line`
+- `grm_pipeline`
+- `exe_simple`
+- `exe_pipeline`
+
+These functions connect major runtime phases and should describe their inputs,
+outputs, error behaviour and ownership expectations.
+
+### Expansion
+
+- `exp_variables`
+
+The documentation should describe allocation ownership, shell-state
+dependency and error reporting.
+
+### Builtin integration
+
+- `blt_is_builtin`
+- `blt_execute`
+- `blt_execute_parent`
+
+Documentation should explain dispatch semantics and, where relevant, why some
+builtins execute in the parent shell process.
+
+### Environment state
+
+- `sta_env_copy`
+- `sta_env_entry`
+- `sta_env_set`
+- `sta_env_unset`
+- `sta_env_value`
+
+Documentation should make allocation and ownership rules explicit where they
+are not obvious from the signature.
+
+### Execution and descriptor state
+
+- `exe_redir_apply`
+- `exe_stdio_save`
+- `exe_stdio_restore`
+
+Documentation should focus on descriptor ownership, side effects and restore
+expectations rather than restating implementation steps.
+
+### Signals
+
+- `sig_set_interactive`
+- `sig_set_heredoc`
+- `sig_set_waiting`
+- `sig_set_child`
+
+Documentation should explain which signal mode each function establishes and
+the runtime context in which that mode is expected.
+
+### Shared cleanup and support
+
+- `scn_token_clear`
+- `grm_clear`
+- `sup_free_array`
+- `sup_join_free_left`
+
+Documentation should emphasize ownership transfer or destruction semantics.
+
+Simple helpers such as `sup_is_space` or counting utilities do not require
+heavy API documentation merely because they happen to be used from multiple
+subsystems.
+
+## Internal Interfaces
+
+A function is not automatically part of the documented API merely because it
+is declared in `minishell.h`.
+
+Many declarations exist there because the original project uses a central
+header for both subsystem interfaces and implementation plumbing.
+
+Single-subsystem functions and file-local static helpers should remain
+undocumented unless a non-obvious contract provides genuine maintenance value.
+
+The repository currently contains 79 static source helpers. They are explicitly
+not a target for mechanical Doxygen coverage.
+
+## Documentation Conventions
+
+Documentation should explain information that cannot be recovered reliably
+from the function or type name alone.
+
+Useful subjects include:
+
+- ownership transfer;
+- allocation responsibility;
+- destruction responsibility;
+- lifecycle expectations;
+- valid state transitions;
+- process ownership;
+- file-descriptor ownership;
+- signal-mode expectations;
+- error reporting;
+- side effects;
+- assumptions that callers must satisfy.
+
+Documentation should not merely restate obvious code.
+
+For example, a comment saying that a function named `sta_env_copy` copies an
+environment is low-value.
+
+A useful comment explains who owns the returned environment, how allocation
+failure is reported and who is responsible for releasing it.
+
+## Doxygen Policy
+
+The intended generated reference should favor documented interfaces over
+exhaustive extraction.
+
+The configuration should therefore:
+
+- avoid treating every declaration as documented automatically;
+- avoid extracting static implementation helpers by default;
+- avoid committing generated HTML output;
+- keep configuration in the repository;
+- allow generation with a single documented local command;
+- treat warnings as information to review deliberately rather than silently
+  hiding documentation problems;
+- remain lightweight enough for contributors to understand without a separate
+  documentation build system.
+
+The initial documentation source boundary should focus on the maintained
+headers rather than presenting every implementation file as public API.
+
+## Existing Libft Documentation
+
+`libft/libft.h` already contains Doxygen-style documentation for its utility
+functions.
+
+That documentation should be preserved and evaluated for consistency with the
+repository-wide convention.
+
+The current workstream does not require rewriting correct Libft comments merely
+to make their wording uniform.
+
+## Historical 42 Headers
+
+All 71 maintained C and header files currently contain the historical 42 file
+banner with `jpedro-g` recorded in the Created and Updated metadata.
+
+Those banners are historical file metadata, not API documentation.
+
+They are not used by Doxygen as part of the maintained documentation model.
+
+Their repository-wide cleanup belongs to the later code-quality audit so that
+historical attribution is handled consistently rather than selectively
+rewritten during API-documentation work.
+
+## Generated Documentation
+
+Generated Doxygen artefacts are build products.
+
+They should not be committed to the repository.
+
+The repository should contain:
+
+- the Doxygen configuration;
+- source-level API comments;
+- documentation-generation instructions.
+
+The generated HTML or other output should remain local unless a later
+workstream deliberately introduces hosted documentation.
+
+## Relationship to Architecture Documentation
+
+Generated API documentation answers questions such as:
+
+- what data does this type contain?
+- what does this interface require?
+- who owns the returned resource?
+- what side effects occur?
+- what error state can be produced?
+
+The hand-written architecture documentation answers broader questions such as:
+
+- how does a command move through the shell?
+- why are modules separated this way?
+- how do parsing, execution and state interact?
+- what design decisions shaped the implementation?
+
+Doxygen supplements that documentation.
+
+It does not replace it.

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -32,56 +32,91 @@
 /*                                  TYPES                                     */
 /* ************************************************************************** */
 
+/**
+ * @brief Token categories produced by the scanner.
+ *
+ * Operator tokens preserve the shell syntax required by the grammar and
+ * execution stages.
+ */
 typedef enum e_toktype
 {
-	TOK_WORD,
-	TOK_PIPE,
-	TOK_REDIR_IN,
-	TOK_REDIR_OUT,
-	TOK_HEREDOC,
-	TOK_APPEND
+	TOK_WORD,       /**< Command word or redirection operand. */
+	TOK_PIPE,       /**< Pipeline separator (`|`). */
+	TOK_REDIR_IN,   /**< Input redirection operator (`<`). */
+	TOK_REDIR_OUT,  /**< Truncating output redirection operator (`>`). */
+	TOK_HEREDOC,    /**< Here-document operator (`<<`). */
+	TOK_APPEND      /**< Appending output redirection operator (`>>`). */
 }	t_toktype;
 
+/**
+ * @brief Error state propagated through parsing-related operations.
+ */
 typedef enum e_err
 {
-	ERR_NONE,
-	ERR_MALLOC,
-	ERR_UNCLOSED_QUOTE,
-	ERR_SYNTAX
+	ERR_NONE,           /**< No error has been reported. */
+	ERR_MALLOC,         /**< Dynamic allocation failed. */
+	ERR_UNCLOSED_QUOTE, /**< Input contains an unterminated quote. */
+	ERR_SYNTAX          /**< Input violates the supported shell grammar. */
 }	t_err;
 
 /* ************************************************************************** */
 /*                               STRUCTURES                                   */
 /* ************************************************************************** */
 
+/**
+ * @brief Node in the scanner token stream.
+ *
+ * Token nodes are consumed by the grammar stage and released with
+ * scn_token_clear().
+ */
 typedef struct s_token
 {
-	t_toktype		type;
-	char			*value;
-	struct s_token	*next;
+	t_toktype		type;  /**< Token category. */
+	char			*value; /**< Owned token payload when present. */
+	struct s_token	*next;  /**< Next token in scanner order. */
 }	t_token;
 
+/**
+ * @brief Redirection attached to a parsed command.
+ *
+ * The grammar owns the duplicated target string. A prepared descriptor is
+ * owned by the node while fd is non-negative and may later be transferred to
+ * execution, which resets fd to -1.
+ */
 typedef struct s_redir
 {
-	t_toktype		type;
-	char			*target;
-	int				fd;
-	struct s_redir	*next;
+	t_toktype		type;   /**< Redirection operator category. */
+	char			*target; /**< Owned redirection target string. */
+	int				fd;     /**< Prepared descriptor, or -1 when absent. */
+	struct s_redir	*next;   /**< Next redirection for the command. */
 }	t_redir;
 
+/**
+ * @brief Parsed command node within a pipeline.
+ *
+ * Each node owns its argument vector and redirection list. Command nodes are
+ * chained in pipeline order and released with grm_clear().
+ */
 typedef struct s_cmd
 {
-	char			**argv;
-	int				argc;
-	t_redir			*redirs;
-	struct s_cmd	*next;
+	char			**argv;   /**< Owned NULL-terminated argument vector. */
+	int				argc;     /**< Number of command arguments. */
+	t_redir			*redirs;  /**< Owned redirection list. */
+	struct s_cmd	*next;     /**< Next command in pipeline order. */
 }	t_cmd;
 
+/**
+ * @brief Mutable state owned by an active shell session.
+ *
+ * The session owns a mutable copy of the environment for its lifetime.
+ * last_status represents the most recently established shell status and is
+ * also used by `$?` expansion and by `exit` when no explicit status is given.
+ */
 typedef struct s_shell
 {
-	char	**envp;
-	int		last_status;
-	int		should_exit;
+	char	**envp;       /**< Owned mutable environment array. */
+	int		last_status; /**< Most recently established shell exit status. */
+	int		should_exit; /**< Non-zero when the parent loop must terminate. */
 }	t_shell;
 
 typedef struct s_tokctx
@@ -219,6 +254,14 @@ int		sta_env_unset(t_shell *shell, const char *name);
 /*                                SIGNALS                                     */
 /* ************************************************************************** */
 
+/**
+ * @brief Signal number recorded by the active input signal handler.
+ *
+ * A value of 0 represents no currently recorded handled signal. Interactive
+ * and heredoc signal modes reset the value when installed. Session and
+ * heredoc control flow inspect the value to react to SIGINT outside the
+ * asynchronous handler itself.
+ */
 extern volatile sig_atomic_t	g_signal;
 
 void	sig_set_interactive(void);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -10,6 +10,14 @@
 /*                                                                            */
 /* ************************************************************************** */
 
+/**
+ * @file minishell.h
+ * @brief Cross-module interface for the Minishell runtime.
+ *
+ * Defines the maintained data model and selected cross-module contracts.
+ * Internal implementation helpers remain intentionally undocumented.
+ */
+
 #ifndef MINISHELL_H
 # define MINISHELL_H
 
@@ -146,6 +154,15 @@ typedef struct s_pipe_state
 /*                                SESSION                                     */
 /* ************************************************************************** */
 
+/**
+ * @brief Run the interactive shell session.
+ *
+ * Creates the shell-owned environment copy, processes input until EOF or an
+ * `exit` request, and releases session resources before returning.
+ *
+ * @param envp Borrowed process environment received from main().
+ * @return Final shell status, or 1 if session initialization fails.
+ */
 int		ses_loop(char **envp);
 int		ses_execute_line(const char *line, t_shell *shell);
 
@@ -153,6 +170,21 @@ int		ses_execute_line(const char *line, t_shell *shell);
 /*                                  SCAN                                      */
 /* ************************************************************************** */
 
+/**
+ * @brief Scan one input line into an owned token list.
+ *
+ * Words are assembled with the current shell state available for expansion.
+ * The error output is reset to ERR_NONE before scanning begins.
+ *
+ * @param line Borrowed input line to scan.
+ * @param shell Borrowed shell state used during word expansion.
+ * @param err Output error state.
+ * @return Owned token list, or NULL on failure or when no tokens are emitted.
+ *
+ * The caller owns a successful result and releases it with scn_token_clear().
+ * When NULL is returned, err distinguishes scanner failure from an empty
+ * result.
+ */
 t_token	*scn_line(const char *line, t_shell *shell, t_err *err);
 char	*scn_word(const char *line, size_t *i,
 			t_shell *shell, t_err *err);
@@ -163,17 +195,46 @@ int		scn_emit_word(t_token **head, char *word, t_err *err);
 int		scn_emit_operator(t_token **head, t_toktype type, t_err *err);
 t_token	*scn_token_new(t_toktype type, char *value);
 void	scn_token_add(t_token **lst, t_token *new_tok);
+/**
+ * @brief Destroy an owned scanner token list.
+ *
+ * Releases each token payload and every node in the list.
+ *
+ * @param lst Token list to destroy; NULL is accepted.
+ */
 void	scn_token_clear(t_token *lst);
 
 /* ************************************************************************** */
 /*                                GRAMMAR                                     */
 /* ************************************************************************** */
 
+/**
+ * @brief Build the command chain represented by a token stream.
+ *
+ * Commands are created in pipeline order. Argument strings and redirection
+ * targets are copied, so ownership of the input token list remains with the
+ * caller.
+ *
+ * @param tokens Borrowed scanner token list.
+ * @param err Output error state for syntax or allocation failures.
+ * @return Owned command chain, or NULL when construction fails.
+ *
+ * A successful result must be released with grm_clear().
+ */
 t_cmd	*grm_pipeline(t_token *tokens, t_err *err);
 t_cmd	*grm_command(t_token *tokens, t_err *err);
 int		grm_count(t_cmd *cmd);
 int		grm_is_redir(t_toktype type);
 int		grm_add_redir(t_cmd *cmd, t_token *tok, t_err *err);
+/**
+ * @brief Destroy an owned command chain.
+ *
+ * Releases each command argument vector, redirection list and command node.
+ * Prepared redirection descriptors still owned by redirection nodes are also
+ * closed during destruction.
+ *
+ * @param cmd Command chain to destroy; NULL is accepted.
+ */
 void	grm_clear(t_cmd *cmd);
 void	grm_redir_clear(t_redir *list);
 
@@ -181,6 +242,19 @@ void	grm_redir_clear(t_redir *list);
 /*                                EXPAND                                      */
 /* ************************************************************************** */
 
+/**
+ * @brief Expand shell variables in a string segment.
+ *
+ * Supports environment-variable expansion and `$?` using the active shell
+ * state.
+ *
+ * @param str Borrowed source string.
+ * @param shell Borrowed shell state used for environment and status lookup.
+ * @param err In/out error state; set to ERR_MALLOC on allocation failure.
+ * @return Newly allocated expanded string, or NULL on failure.
+ *
+ * The caller owns the returned string.
+ */
 char	*exp_variables(const char *str, t_shell *shell, t_err *err);
 int		exp_name_start(char c);
 int		exp_name_char(char c);
@@ -190,7 +264,33 @@ char	*exp_env_value(char *name, t_shell *shell, t_err *err);
 /*                                  EXEC                                      */
 /* ************************************************************************** */
 
+/**
+ * @brief Execute a standalone parsed command.
+ *
+ * Redirections are prepared before dispatch. Redirection-only commands are
+ * applied without launching a program. Standalone builtins execute in the
+ * parent shell so persistent state changes survive; external commands execute
+ * in a child process.
+ *
+ * @param cmd Borrowed command node.
+ * @param shell Mutable shell session state.
+ * @param tokens Borrowed token list for child cleanup context.
+ * @return Shell-style execution status.
+ */
 int		exe_simple(t_cmd *cmd, t_shell *shell, t_token *tokens);
+/**
+ * @brief Execute a parsed command pipeline.
+ *
+ * Heredocs are prepared before pipeline children are launched. Pipeline
+ * stages execute in child processes, and the resulting status is derived from
+ * the final pipeline process.
+ *
+ * @param cmds Borrowed command chain in pipeline order.
+ * @param shell Borrowed shell state inherited by pipeline children.
+ * @param tokens Borrowed token list for child cleanup context.
+ * @return Pipeline status, or the status produced by heredoc preparation
+ * failure.
+ */
 int		exe_pipeline(t_cmd *cmds, t_shell *shell, t_token *tokens);
 void	exe_child(t_cmd *cmd, t_child_ctx *ctx);
 int		exe_notfound_muted(t_cmd *cmd, t_child_ctx *ctx);
@@ -204,6 +304,19 @@ int		exe_pipe_wait(pid_t last_pid);
 int		exe_pipe_heredocs(t_cmd *cmds, t_child_ctx *ctx, int *status);
 int		exe_redir_prepare(t_cmd *cmd, t_child_ctx *ctx, int *status);
 int		exe_heredocs_prepare(t_cmd *cmd, t_child_ctx *ctx, int *status);
+/**
+ * @brief Apply a command's redirections to the current process.
+ *
+ * Redirections are processed in source order. The last applicable input and
+ * output descriptors become the effective standard streams. Prepared
+ * descriptors stored in redirection nodes are consumed and reset to -1.
+ *
+ * @param cmd Borrowed command containing the redirection list.
+ * @param status Output status updated when a redirection operation fails.
+ * @return 0 on success, 1 on failure.
+ *
+ * On success, STDIN_FILENO and/or STDOUT_FILENO may have been replaced.
+ */
 int		exe_redir_apply(t_cmd *cmd, int *status);
 int		exe_redir_one(t_redir *r, int *in_fd,
 			int *out_fd, int *status);
@@ -217,15 +330,62 @@ int		exe_heredoc_save_terminal(struct termios *saved);
 void	exe_heredoc_restore(struct termios *saved, int has_saved);
 char	*exe_path_find(const char *cmd, char **envp);
 int		exe_path_direct(const char *cmd);
+/**
+ * @brief Duplicate the current standard input and output descriptors.
+ *
+ * On success, ownership of both duplicated descriptors is returned to the
+ * caller and is normally transferred to exe_stdio_restore().
+ *
+ * @param stdin_save Output descriptor duplicating STDIN_FILENO.
+ * @param stdout_save Output descriptor duplicating STDOUT_FILENO.
+ * @return 0 on success, 1 if either duplication fails.
+ */
 int		exe_stdio_save(int *stdin_save, int *stdout_save);
+/**
+ * @brief Restore standard input and output from saved descriptors.
+ *
+ * Both saved descriptors are closed before the function returns, including
+ * when a dup2() operation fails. This function therefore consumes them.
+ *
+ * @param stdin_save Saved standard-input descriptor.
+ * @param stdout_save Saved standard-output descriptor.
+ * @return 0 when both streams are restored, otherwise 1.
+ */
 int		exe_stdio_restore(int stdin_save, int stdout_save);
 
 /* ************************************************************************** */
 /*                                BUILTINS                                    */
 /* ************************************************************************** */
 
+/**
+ * @brief Test whether a command name is a supported shell builtin.
+ *
+ * @param cmd Borrowed command name; NULL is accepted.
+ * @return Non-zero for a supported builtin, otherwise 0.
+ */
 int		blt_is_builtin(const char *cmd);
+/**
+ * @brief Dispatch a builtin in the current process.
+ *
+ * Builtins such as cd, export, unset and exit may modify the supplied shell
+ * state.
+ *
+ * @param cmd Borrowed parsed command.
+ * @param shell Mutable shell state available to stateful builtins.
+ * @return Status returned by the selected builtin, or 1 when dispatch fails.
+ */
 int		blt_execute(t_cmd *cmd, t_shell *shell);
+/**
+ * @brief Execute a standalone builtin in the parent shell process.
+ *
+ * Parent standard input and output are saved before command redirections are
+ * applied and restored afterwards. Executing here allows persistent builtin
+ * state changes to survive the command.
+ *
+ * @param cmd Borrowed parsed builtin command.
+ * @param shell Mutable parent-shell state.
+ * @return Builtin status, or 1 on stdio save or restore failure.
+ */
 int		blt_execute_parent(t_cmd *cmd, t_shell *shell);
 int		blt_echo(t_cmd *cmd);
 int		blt_pwd(void);
@@ -242,12 +402,59 @@ void	blt_identifier_error(const char *name, const char *arg);
 /*                                  STATE                                     */
 /* ************************************************************************** */
 
+/**
+ * @brief Create a deep copy of an environment array.
+ *
+ * @param envp Borrowed NULL-terminated environment array.
+ * @return Newly allocated environment copy, or NULL on allocation failure.
+ *
+ * The caller owns both the returned array and its duplicated strings.
+ */
 char	**sta_env_copy(char **envp);
+/**
+ * @brief Allocate a `KEY=value` environment entry.
+ *
+ * @param key Borrowed variable name.
+ * @param value Borrowed variable value.
+ * @return Newly allocated entry, or NULL on allocation failure.
+ *
+ * The caller owns the returned string.
+ */
 char	*sta_env_entry(const char *key, const char *value);
 int		sta_env_count(char **envp);
 int		sta_env_index(char **envp, const char *name);
+/**
+ * @brief Look up the value portion of an environment entry.
+ *
+ * @param name Borrowed variable name.
+ * @param envp Borrowed NULL-terminated environment array.
+ * @return Borrowed pointer to the value, or an empty string when not found.
+ *
+ * The returned pointer is not owned by the caller and must not be freed.
+ */
 char	*sta_env_value(const char *name, char **envp);
+/**
+ * @brief Add or update an entry in the shell-owned environment.
+ *
+ * Existing entries are replaced when an assignment is supplied. A new entry
+ * extends the environment array while preserving ownership of existing
+ * strings.
+ *
+ * @param shell Mutable shell whose environment is updated.
+ * @param entry Borrowed environment entry or variable name.
+ * @return 0 on success or no-op, 1 on allocation failure.
+ */
 int		sta_env_set(t_shell *shell, const char *entry);
+/**
+ * @brief Remove a named entry from the shell-owned environment.
+ *
+ * The removed string and previous environment array are released. Surviving
+ * strings remain owned by the replacement environment array.
+ *
+ * @param shell Mutable shell whose environment is updated.
+ * @param name Borrowed variable name.
+ * @return 0 on success or when absent, 1 on allocation failure.
+ */
 int		sta_env_unset(t_shell *shell, const char *name);
 
 /* ************************************************************************** */
@@ -264,9 +471,33 @@ int		sta_env_unset(t_shell *shell, const char *name);
  */
 extern volatile sig_atomic_t	g_signal;
 
+/**
+ * @brief Install signal behaviour for the interactive prompt.
+ *
+ * Resets g_signal, handles SIGINT through the interactive handler and ignores
+ * SIGQUIT. Readline's own signal catching is disabled.
+ */
 void	sig_set_interactive(void);
+/**
+ * @brief Install signal behaviour while collecting heredoc input.
+ *
+ * Resets g_signal, installs the heredoc SIGINT handler and ignores SIGQUIT.
+ * The SIGINT handler records the signal and interrupts heredoc input.
+ */
 void	sig_set_heredoc(void);
+/**
+ * @brief Install parent-shell signal behaviour while waiting for children.
+ *
+ * Both SIGINT and SIGQUIT are ignored so foreground child processes handle
+ * those signals according to their own policy.
+ */
 void	sig_set_waiting(void);
+/**
+ * @brief Restore normal execution signals in a child process.
+ *
+ * SIGINT and SIGQUIT are both restored to their default dispositions before
+ * child command execution.
+ */
 void	sig_set_child(void);
 
 /* ************************************************************************** */
@@ -274,7 +505,26 @@ void	sig_set_child(void);
 /* ************************************************************************** */
 
 int		sup_is_space(char c);
+/**
+ * @brief Destroy an owned NULL-terminated string array.
+ *
+ * Releases every contained string followed by the array itself.
+ *
+ * @param str Owned string array to destroy; NULL is accepted.
+ */
 void	sup_free_array(char **str);
+/**
+ * @brief Concatenate two strings while consuming the left operand.
+ *
+ * The first string is freed whether allocation succeeds or fails. The second
+ * string remains owned by the caller.
+ *
+ * @param s1 Owned left string; NULL is treated as empty and is consumed.
+ * @param s2 Borrowed right string; NULL is treated as empty.
+ * @return Newly allocated concatenation, or NULL on allocation failure.
+ *
+ * The caller owns a successful return value.
+ */
 char	*sup_join_free_left(char *s1, char *s2);
 
 #endif

--- a/libft/libft.h
+++ b/libft/libft.h
@@ -10,6 +10,15 @@
 /*                                                                            */
 /* ************************************************************************** */
 
+/**
+ * @file libft.h
+ * @brief Utility interfaces used by the Minishell implementation.
+ *
+ * Provides the maintained Libft subset bundled with this repository.
+ * Function-level contracts document allocation, ownership and basic
+ * behavioural guarantees where relevant.
+ */
+
 #ifndef LIBFT_H
 # define LIBFT_H
 


### PR DESCRIPTION
## Summary

Establishes a maintained API-documentation baseline for Minishell using a
repository-controlled Doxygen configuration and selectively documented
interfaces.

The documentation focuses on meaningful cross-module contracts, data
structures, ownership, lifecycle and side effects rather than mechanically
documenting every function in the project.

Closes #46.

## What changed

- added a lightweight repository-controlled `Doxyfile`;
- documented the API-documentation boundary and conventions;
- documented the core Minishell data model:
  - token and error enums;
  - token nodes;
  - redirections;
  - parsed commands;
  - shell session state;
  - global signal state;
- documented selected cross-module contracts across:
  - session handling;
  - scanning;
  - grammar;
  - variable expansion;
  - execution;
  - builtin dispatch;
  - environment state;
  - signal modes;
  - resource cleanup;
- documented ownership and lifecycle expectations for strings, arrays,
  descriptors and shell state;
- published the existing documented Libft utility interface;
- kept internal implementation structures and helpers outside the generated
  API boundary;
- documented reproducible local Doxygen generation;
- updated the repository README to reflect the maintained API and ownership
  documentation baseline.

## Documentation boundary

Doxygen intentionally uses:

    EXTRACT_ALL = NO
    EXTRACT_STATIC = NO

The maintained API is therefore curated rather than generated from every
declaration in the repository.

`include/minishell.h` and `libft/libft.h` are explicitly documented with
`@file`, allowing their selected documented interfaces to be published while
undocumented implementation details remain hidden.

Hand-written architecture documentation remains authoritative for system-level
design. Doxygen supplements it with interface-level contracts.

## Historical preservation

The original 42 file banners and contributor metadata were not selectively
rewritten or removed as part of this work.

Repository-wide treatment of those historical headers remains outside this
issue and belongs to the later code-quality audit.

## Validation

Validated locally with:

- reference `make` build using the historical `CC = cc` interface;
- supplemental `make CC=clang` build;
- `git diff --check`;
- Doxygen 1.9.8 generation;
- zero Doxygen warnings;
- generated `minishell_8h.html`;
- generated `libft_8h.html`;
- generated function, enum and variable indexes;
- confirmation that selected internal structures and helpers are not exposed;
- confirmation that generated documentation under `build/` remains ignored.

No runtime behaviour was changed.