### PR TITLE
docs(release): define maintained release strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,9 @@ The maintained API-documentation strategy is defined in
 The maintained post-baseline evolution policy is defined in
 [`docs/development/evolution-roadmap.md`](docs/development/evolution-roadmap.md).
 
+Historical-baseline and maintained-release policy is defined in
+[`docs/development/release-strategy.md`](docs/development/release-strategy.md).
+
 A repository-controlled [`Doxyfile`](Doxyfile) generates a local HTML reference
 for the curated Minishell and Libft API boundary. Generated output remains
 under `build/` and is not versioned.
@@ -569,8 +572,12 @@ Current focused correctness follow-ups include:
 
 These fixes are tracked separately from documentation-only modernization work.
 
-The remaining portfolio-modernization work focuses on historical
-baseline/release strategy and the final portfolio audit.
+The maintained release strategy is now defined separately from the historical
+baseline.
+
+The first maintained `v1.0.0` release is intentionally not created yet.
+Current P1 correctness issues #49 and #50 must be resolved, and the final
+portfolio audit must establish release readiness first.
 
 Broader automated regression testing, further maintenance improvements and
 optional post-42 technical exploration remain possible future directions rather

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -25,6 +25,8 @@ For contributors and maintainers beginning from the repository root:
 - [`evolution-roadmap.md`](evolution-roadmap.md) defines how correctness,
   maintenance, optional post-42 work and experiments should evolve beyond the
   preserved historical baseline.
+- [`release-strategy.md`](release-strategy.md) defines historical-reference,
+  maintained-version and portfolio-release policy.
 - [`api-documentation.md`](api-documentation.md) defines the maintained
   API-documentation boundary, documentation conventions and Doxygen strategy.
 

--- a/docs/development/evolution-roadmap.md
+++ b/docs/development/evolution-roadmap.md
@@ -479,7 +479,7 @@ At the time this roadmap was established:
 - automated behavioural regression testing remains a useful future engineering
   direction;
 - optional post-42 capabilities remain non-committed;
-- release strategy is intentionally handled by a separate workstream;
+- maintained release strategy is defined in `release-strategy.md`;
 - final portfolio review remains a separate closing workstream.
 
 The roadmap should be updated when the evolution policy itself changes, not

--- a/docs/development/evolution-roadmap.md
+++ b/docs/development/evolution-roadmap.md
@@ -434,15 +434,26 @@ The repository intentionally preserves both stories:
 
 ## Release Relationship
 
-This roadmap does not define the final release or tag strategy.
+The maintained historical-baseline and release policy is defined in:
 
-The dedicated historical-baseline and release-strategy workstream should define
-how maintained release references coexist with:
+[`release-strategy.md`](release-strategy.md)
+
+The release strategy preserves the distinction between:
 
     portfolio-baseline-2026-08
 
-That work should preserve the distinction between historical provenance and a
-later portfolio-ready maintained release.
+as an immutable historical reference and semantic-version maintained releases
+such as:
+
+    v1.0.0
+
+The first maintained release is intentionally gated by unresolved P1
+correctness work and the final portfolio audit.
+
+This roadmap determines how future work is categorized and prioritized.
+
+The release strategy determines when a maintained repository state is ready to
+be published as a versioned release.
 
 ## Non-Commitment Principle
 

--- a/docs/development/release-strategy.md
+++ b/docs/development/release-strategy.md
@@ -1,0 +1,517 @@
+# Historical Baseline and Maintained Release Strategy
+
+This document defines how historical Git references, maintained versions and
+GitHub Releases are used in the Minishell repository.
+
+The repository intentionally preserves two different stories:
+
+- the original 42 project as it existed before professional modernization;
+- the later maintained repository used as a software-engineering portfolio.
+
+Those histories must remain distinguishable.
+
+## Reference Model
+
+The repository uses three different concepts.
+
+### Historical Baseline
+
+The immutable historical reference is:
+
+    portfolio-baseline-2026-08
+
+It identifies the repository state immediately before professional portfolio
+modernization.
+
+### Maintained Branch
+
+The `main` branch represents the current maintained repository state.
+
+It evolves as issues and pull requests are completed.
+
+### Maintained Release
+
+A maintained release is a deliberately selected, validated state of `main`
+published through a versioned annotated Git tag and corresponding GitHub
+Release.
+
+A maintained release is therefore different from both the historical baseline
+and an arbitrary commit on `main`.
+
+## Historical Baseline
+
+The annotated tag:
+
+    portfolio-baseline-2026-08
+
+resolves to:
+
+    7ba2005223e263964bf8ae3069da9ff54c2c2c2b
+
+The referenced commit is:
+
+    7ba2005 Final tests and checks (#25)
+
+This tag preserves the project state before professional portfolio
+modernization.
+
+It is an historical reference, not a maintained software release.
+
+### Historical-Baseline Invariants
+
+`portfolio-baseline-2026-08` must:
+
+- remain immutable;
+- continue to point to the same historical commit;
+- never be moved to follow `main`;
+- never be reused as a maintained version;
+- never be renamed to imitate a semantic-version release;
+- remain available for comparison with later maintained development.
+
+The tag may be documented more fully in the future, but its target must not
+change.
+
+### What the Historical Baseline Represents
+
+The historical baseline preserves evidence of:
+
+- the original Minishell implementation;
+- the original collaborative development history;
+- project-era repository state;
+- historical source metadata;
+- original evaluation and validation context.
+
+Later documentation, CI, quality tooling, maintenance work and runtime fixes
+must not be presented as though they existed in that historical state.
+
+## Maintained Main Branch
+
+`main` is the repository's evolving maintained baseline.
+
+A merge into `main` establishes a new maintained repository state, but does not
+automatically create a release.
+
+This distinction is intentional.
+
+Examples of work that may exist on `main` between releases include:
+
+- documentation improvements;
+- repository-maintenance changes;
+- correctness fixes;
+- CI and tooling improvements;
+- refactoring;
+- optional post-42 development.
+
+Not every merged pull request requires a new release.
+
+## Maintained Version Tags
+
+Maintained software releases use conventional semantic-version-style tags:
+
+    vMAJOR.MINOR.PATCH
+
+Examples:
+
+    v1.0.0
+    v1.0.1
+    v1.1.0
+    v2.0.0
+
+The `v` prefix distinguishes maintained software versions clearly from the
+historical tag:
+
+    portfolio-baseline-2026-08
+
+This familiar format is preferred over repository-specific names such as
+`portfolio-v1` or date-only maintained releases.
+
+## Semantic-Version Interpretation
+
+The repository uses Semantic Versioning concepts as a practical release
+communication model.
+
+Minishell is not a packaged library with a formally versioned public API, so
+version numbers describe the maintained project contract rather than claiming
+strict library ABI compatibility.
+
+The relevant contract includes:
+
+- supported command behaviour;
+- documented shell semantics;
+- maintained user-visible capabilities;
+- repository expectations that materially affect use of the project.
+
+### PATCH
+
+Increment PATCH for release-worthy compatible maintenance that does not add a
+new supported capability or intentionally break existing maintained behaviour.
+
+Typical examples include:
+
+- correctness fixes;
+- narrow reliability fixes;
+- error-path fixes;
+- resource-ownership fixes;
+- documentation corrections shipped with maintained fixes;
+- tooling or maintenance updates included in a patch release.
+
+Example:
+
+    v1.0.0 -> v1.0.1
+
+Documentation-only or tooling-only changes do not require an immediate release
+by themselves.
+
+If they are included in a later release, the version is determined by the
+highest-impact change included in that release.
+
+### MINOR
+
+Increment MINOR when the maintained project gains a new backwards-compatible
+capability or substantial compatible functionality.
+
+Typical examples include:
+
+- a new supported shell feature;
+- a significant compatible post-42 capability;
+- substantial new validation or tooling functionality when it materially
+  changes the maintained project offering.
+
+Example:
+
+    v1.0.1 -> v1.1.0
+
+Any capability beyond the original 42 subject must remain explicitly described
+as post-42 development.
+
+### MAJOR
+
+Increment MAJOR when a maintained release intentionally introduces an
+incompatible change to an established supported contract.
+
+Examples could include:
+
+- deliberately incompatible shell behaviour;
+- removal of previously maintained supported behaviour;
+- a major interface or usage-contract redesign.
+
+Example:
+
+    v1.4.2 -> v2.0.0
+
+A large internal refactor alone does not require a major-version increment if
+the maintained external behaviour remains compatible.
+
+## Pre-1.0 Policy
+
+The repository does not need to create provisional `v0.x` releases merely
+because modernization work exists on `main`.
+
+The intended first maintained portfolio release is:
+
+    v1.0.0
+
+That version should represent a consciously validated professional repository
+baseline rather than an intermediate modernization checkpoint.
+
+Until its release-readiness gates pass, `main` remains the maintained
+development baseline without a semantic-version release tag.
+
+## Release Readiness
+
+A stable maintained release must be created deliberately.
+
+At minimum, the candidate commit should satisfy the following gates.
+
+### Repository State
+
+- the release candidate is on protected `main`;
+- local `main` and `origin/main` resolve to the intended commit;
+- the working tree is clean;
+- the release candidate was integrated through the maintained pull-request
+  workflow;
+- no temporary release branch is required after the candidate is on `main`.
+
+### Build and CI
+
+- `CI / build` passes for the candidate state;
+- `CI / quality` passes for the candidate state;
+- the reference `make` build succeeds;
+- the supplemental `make CC=clang` build succeeds;
+- compiler warnings remain within the maintained zero-warning build baseline.
+
+### Documentation
+
+- maintained documentation reflects current behaviour;
+- architecture documentation remains consistent with the implementation;
+- known limitations are documented;
+- the evolution roadmap reflects the current policy;
+- release notes can distinguish historical, maintained and post-42 work.
+
+### Repository Hygiene
+
+- generated documentation is not versioned;
+- analyzer build artefacts are not versioned;
+- `git diff --check` passes for the final release work;
+- historical references remain unchanged.
+
+### Quality Findings
+
+P0 findings block a stable maintained release.
+
+P1 correctness findings should also normally be resolved before a stable
+maintained release.
+
+If a future release intentionally ships with an unresolved P1 finding, that
+must be an explicit documented release decision rather than an accidental
+omission.
+
+The first maintained `v1.0.0` release has a stricter rule:
+
+    no known open P0 or P1 correctness issue
+
+There is no exception to that rule for the first maintained release.
+
+## Current P1 Release Gates
+
+The current evolution roadmap identifies two P1 correctness issues.
+
+### #49 Parent Redirection Recovery
+
+Issue #49 covers demonstrated parent-process redirection failure-path defects,
+including descriptor ownership and standard-stream restoration.
+
+Release policy:
+
+    BLOCKS v1.0.0
+
+### #50 Literal-Dollar Allocation Failure
+
+Issue #50 covers missing allocation-error propagation in the literal-dollar
+expansion path.
+
+Release policy:
+
+    BLOCKS v1.0.0
+
+Both issues should be resolved and validated before the first maintained
+release is created.
+
+## Final Portfolio Audit Gate
+
+The final portfolio audit is also a prerequisite for `v1.0.0`.
+
+Its purpose is different from the correctness gates.
+
+The P1 issues answer:
+
+    Are known demonstrated correctness defects still open?
+
+The final portfolio audit answers:
+
+    Is the repository as a whole internally consistent, validated and ready to
+    be presented as the maintained portfolio release?
+
+Therefore the first maintained release sequence is:
+
+    define release strategy
+            |
+            v
+    resolve required P1 issues
+            |
+            v
+    final portfolio audit
+            |
+            v
+    validate release candidate on main
+            |
+            v
+    create annotated v1.0.0 tag
+            |
+            v
+    publish matching GitHub Release
+
+## Annotated Git Tags
+
+Maintained release tags should be annotated Git tags.
+
+Example:
+
+    git tag -a v1.0.0 -m "Minishell maintained release v1.0.0"
+
+Annotated tags are preferred because they preserve explicit tag metadata and a
+human-readable release annotation.
+
+A maintained release tag must point to the exact `main` commit selected as the
+release candidate.
+
+Release tags must not be moved after publication.
+
+If a released state later requires correction, create a new version rather
+than retargeting the existing tag.
+
+For example:
+
+    v1.0.0
+        |
+        +-- defect discovered
+                |
+                v
+             v1.0.1
+
+## GitHub Releases
+
+Each stable maintained semantic-version tag should normally have a matching
+GitHub Release.
+
+The relationship is:
+
+    validated main commit
+            |
+            v
+    annotated Git tag
+            |
+            v
+    GitHub Release for the same tag
+
+The Git tag is the versioned Git reference.
+
+The GitHub Release is the human-facing publication layer containing release
+context and notes.
+
+A GitHub Release must not point to a different source state from its named
+version tag.
+
+## Minimum Release Notes
+
+A maintained GitHub Release should contain enough information for a reviewer
+to understand what the release represents.
+
+At minimum, include:
+
+- release purpose;
+- major changes since the previous maintained release;
+- validation performed;
+- known limitations;
+- relevant correctness fixes;
+- any optional post-42 capabilities included;
+- a reference to the historical baseline where useful.
+
+For `v1.0.0`, the release notes should explicitly explain that:
+
+- it is the first professionally maintained portfolio release;
+- it is not the original 42 evaluation state;
+- the original pre-modernization state remains preserved at
+  `portfolio-baseline-2026-08`;
+- later modernization and correctness work is intentionally distinguishable
+  through Git history.
+
+## Historical Baseline and GitHub Releases
+
+`portfolio-baseline-2026-08` does not need to be converted into a conventional
+GitHub software release.
+
+Its primary purpose is historical comparison and provenance.
+
+If GitHub UI documentation is ever added for that tag, it must remain clearly
+labelled as an historical baseline rather than `v1.0.0` or another maintained
+software release.
+
+## Release Procedure
+
+When a maintained release candidate is ready:
+
+1. confirm all release-readiness gates;
+2. confirm the intended commit is on `main`;
+3. confirm local `main` and `origin/main` match;
+4. confirm the working tree is clean;
+5. run the documented local validation;
+6. confirm required GitHub Actions checks are green;
+7. verify known P0/P1 findings against the release policy;
+8. verify the historical baseline still resolves to its immutable commit;
+9. create the annotated semantic-version tag;
+10. push that tag;
+11. create the matching GitHub Release;
+12. verify the GitHub Release resolves to the same tag and commit.
+
+The exact terminal commands should be chosen at release time after the final
+candidate commit is known.
+
+This document deliberately does not hard-code a future release commit hash.
+
+## Post-Release Development
+
+After a maintained release, normal issue-driven development continues from
+`main`.
+
+A released version remains immutable.
+
+Later work should result in:
+
+- no release when a merged change does not justify publication;
+- a PATCH release for compatible correctness or maintenance work;
+- a MINOR release for new compatible maintained capabilities;
+- a MAJOR release for intentional incompatible maintained-contract changes.
+
+The version decision should reflect the highest-impact change since the
+previous maintained release.
+
+## Optional Post-42 Development
+
+Optional capabilities beyond the original 42 subject may be included in future
+maintained releases.
+
+When they are included:
+
+- they must be labelled as post-42 work;
+- release notes must not imply they existed in the historical project;
+- historical documentation must not be rewritten to include them;
+- the version increment should reflect their maintained behavioural impact.
+
+The historical baseline remains unchanged regardless of later capabilities.
+
+## Relationship to the Evolution Roadmap
+
+The evolution roadmap defines:
+
+- how future work is categorized;
+- how P0-P3 priorities are interpreted;
+- how historical and maintained development remain separate.
+
+This release strategy defines:
+
+- when a maintained state becomes a release;
+- how that release is named;
+- which quality gates apply;
+- how Git tags and GitHub Releases represent it.
+
+The two documents are complementary.
+
+## Non-Goals
+
+This release strategy does not:
+
+- implement #49;
+- implement #50;
+- create `v1.0.0`;
+- create any GitHub Release;
+- modify `portfolio-baseline-2026-08`;
+- turn every `main` commit into a release;
+- require every documentation change to increment a version;
+- define speculative post-42 features.
+
+## Current Release State
+
+At the time this strategy was established:
+
+- `portfolio-baseline-2026-08` is the only existing tag;
+- it is an annotated historical tag;
+- no semantic-version maintained release exists;
+- `main` is the current maintained development baseline;
+- #49 remains an open P1 correctness gate;
+- #50 remains an open P1 correctness gate;
+- the final portfolio audit has not yet established release readiness;
+- `v1.0.0` must therefore not be created yet.
+
+The first maintained portfolio release becomes eligible only after its
+documented readiness gates pass.


### PR DESCRIPTION
## Summary

Defines the historical-baseline, versioning and maintained-release strategy
for Minishell.

The strategy separates the immutable original 42 project reference from the
actively maintained repository and establishes explicit readiness gates for
the first professional portfolio release.

Closes #56.

## What changed

- added `docs/development/release-strategy.md`;
- linked the release strategy from the development documentation index;
- linked the strategy from the repository README;
- integrated release policy with the post-baseline evolution roadmap;
- defined the role and invariants of `portfolio-baseline-2026-08`;
- distinguished the historical baseline, maintained `main` and maintained
  releases;
- established semantic-version-style maintained tags using
  `vMAJOR.MINOR.PATCH`;
- documented PATCH, MINOR and MAJOR version semantics;
- defined release-readiness gates;
- classified #49 and #50 as blockers for the first `v1.0.0`;
- made the final portfolio audit a prerequisite for `v1.0.0`;
- defined annotated Git-tag policy;
- defined the relationship between Git tags and GitHub Releases;
- documented minimum release-note expectations;
- documented the release procedure without prematurely creating a tag or
  release.

## Historical baseline

The existing annotated tag remains:

    portfolio-baseline-2026-08

and still resolves to:

    7ba2005223e263964bf8ae3069da9ff54c2c2c2b

This reference represents the repository immediately before professional
portfolio modernization.

It is:

- historical;
- immutable;
- not a maintained software release;
- not moved as `main` evolves;
- not reused as a semantic-version tag.

## Maintained release model

The maintained branch and releases have separate roles.

`main` represents the evolving maintained repository.

A maintained release represents a deliberately validated state of `main`
published through:

    annotated semantic-version Git tag
                +
        matching GitHub Release

Maintained release tags use:

    vMAJOR.MINOR.PATCH

The intended first maintained release is:

    v1.0.0

No provisional `v0.x` release is required merely because modernization work
exists on `main`.

## Semantic-version interpretation

Semantic Versioning concepts are used as a practical release-communication
model.

Minishell is not treated as a packaged library with a formally versioned ABI.

Version numbers instead describe changes to the maintained project contract,
including supported behaviour and documented user-visible capabilities.

The strategy defines:

- PATCH for compatible correctness and maintenance work;
- MINOR for new compatible maintained capabilities;
- MAJOR for intentional incompatible maintained-contract changes.

## First release gates

The first `v1.0.0` release requires:

- protected and synchronized `main`;
- clean repository state;
- passing `CI / build`;
- passing `CI / quality`;
- successful reference `make` build;
- successful supplemental Clang build;
- current and internally consistent documentation;
- repository hygiene checks;
- no open P0 or P1 correctness issues;
- successful final portfolio audit.

## Current blockers

### #49

Parent-process redirection recovery and descriptor ownership on `dup2()`
failure paths.

Release policy:

    BLOCKS v1.0.0

### #50

Allocation-error propagation during literal-dollar expansion.

Release policy:

    BLOCKS v1.0.0

Both must be resolved and validated before the first maintained release.

## Final portfolio audit

The final portfolio audit is also a release gate.

The intended sequence is:

    release strategy
          |
          v
    resolve required P1 issues
          |
          v
    final portfolio audit
          |
          v
    validate release candidate on main
          |
          v
    create annotated v1.0.0 tag
          |
          v
    publish matching GitHub Release

## Tag and GitHub Release policy

Maintained releases use annotated Git tags.

Release tags:

- point to the exact selected `main` commit;
- are immutable after publication;
- are never retargeted after a defect is discovered.

A later correction receives a new version instead.

Each stable maintained semantic-version tag should normally have a matching
GitHub Release pointing to the same source state.

## Validation

- no runtime source code changed;
- `portfolio-baseline-2026-08` remains unchanged;
- its target remains
  `7ba2005223e263964bf8ae3069da9ff54c2c2c2b`;
- it remains the repository's only existing tag;
- no semantic-version release was created;
- #49 and #50 are explicitly represented as P1 release blockers;
- the final portfolio audit is explicitly represented as a release gate;
- release policy is integrated with the evolution roadmap;
- stale release-strategy wording was removed;
- `git diff --check` passes;
- working tree is clean.

## Release creation

This pull request defines policy only.

It deliberately does not create:

- `v1.0.0`;
- another Git tag;
- a GitHub Release.

The first maintained release will be created only after the documented
readiness gates pass.