### PR TITLE
fix(exec): harden parent redirection recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,19 +565,19 @@ The repository now distinguishes explicitly between the preserved historical
 The post-baseline evolution policy is defined in
 [`docs/development/evolution-roadmap.md`](docs/development/evolution-roadmap.md).
 
-Current focused correctness follow-ups include:
+Post-baseline correctness work currently includes:
 
-- issue #49 for parent-process redirection recovery;
-- issue #50 for literal-dollar allocation-error propagation.
+- resolved issue #49 for parent-process redirection recovery;
+- open issue #50 for literal-dollar allocation-error propagation.
 
-These fixes are tracked separately from documentation-only modernization work.
+These fixes remain distinguishable from documentation-only modernization work.
 
 The maintained release strategy is now defined separately from the historical
 baseline.
 
 The first maintained `v1.0.0` release is intentionally not created yet.
-Current P1 correctness issues #49 and #50 must be resolved, and the final
-portfolio audit must establish release readiness first.
+Issue #49 has resolved one P1 correctness gate. Issue #50 remains open, and the
+final portfolio audit must still establish release readiness.
 
 Broader automated regression testing, further maintenance improvements and
 optional post-42 technical exploration remain possible future directions rather

--- a/docs/development/code-quality.md
+++ b/docs/development/code-quality.md
@@ -378,11 +378,12 @@ This is especially relevant in persistent parent-process execution through:
 A child-process descriptor leak would disappear when that child exits, while a
 descriptor leaked by the shell process can survive subsequent commands.
 
-Follow-up:
+Resolution:
 
     #49 Harden parent redirection recovery on dup2 failures
 
-No behaviour-changing fix is included in this audit workstream.
+Issue #49 closes the transferred-descriptor ownership gap by explicitly
+closing any still-pending output descriptor when input `dup2()` fails.
 
 ### `Q48-R2`: `wait()` / `waitpid()` interruption handling
 
@@ -426,12 +427,16 @@ The parent callers also perform restoration after an `exe_redir_apply()`
 failure without currently using the restoration return value to override the
 existing command status.
 
-Follow-up:
+Resolution:
 
     #49 Harden parent redirection recovery on dup2 failures
 
+Issue #49 retries interrupted standard-stream restoration, still attempts both
+streams when one restore fails and treats unrecoverable restoration failure as
+fatal to the persistent shell session.
+
 This defect shares the same parent-redirection ownership boundary as
-`Q48-R1`, so both are tracked through the same focused technical issue.
+`Q48-R1`, so both are resolved through the same focused technical issue.
 
 ### `Q48-R4`: Readline operations from the interactive signal handler
 
@@ -488,8 +493,11 @@ Heredoc descriptors:
 Standard-stream backups:
 
 - clean up partial `dup()` success during save;
-- attempt best-effort restoration of both streams;
-- require the dedicated #49 follow-up for failure-path ownership guarantees.
+- retry interrupted restoration attempts;
+- attempt restoration of both streams even if one fails;
+- consume saved descriptors exactly once;
+- terminate the persistent session when restoration can no longer be
+  guaranteed.
 
 The audit therefore found no justification for a broad execution refactor.
 The demonstrated defects are isolated to parent-process redirection recovery
@@ -913,7 +921,7 @@ The completed code-quality audit establishes the following baseline:
 - legacy 42 banners: removed uniformly after historical preservation and attribution were verified;
 - broad include redistribution: not justified at this stage;
 - generated analyzer artefacts: not versioned;
-- parent redirection failure-path defects: tracked in #49;
+- parent redirection failure-path defects: resolved by #49;
 - `wait()` / `waitpid()` interruption handling: accepted trade-off;
 - interactive Readline signal-handler behaviour: plausible risk requiring
   focused future investigation;

--- a/docs/development/evolution-roadmap.md
+++ b/docs/development/evolution-roadmap.md
@@ -94,7 +94,7 @@ They should:
 - include appropriate validation;
 - update documentation when a maintained contract changes.
 
-Known examples are tracked in #49 and #50.
+Known correctness work includes the resolved #49 follow-up and the remaining #50 follow-up.
 
 ### Maintenance and Reliability
 
@@ -262,7 +262,7 @@ Examples include:
 - missing allocation-error propagation;
 - incorrect status or state handling.
 
-Current issues #49 and #50 belong to this correctness queue.
+Issue #49 has been resolved from this correctness queue; #50 remains current P1 work.
 
 Their exact implementation order may be chosen independently, but they should
 normally precede optional post-42 feature work.
@@ -300,21 +300,27 @@ The code-quality audit identified two focused runtime defects.
 
 ### #49: Parent Redirection Recovery
 
-Issue #49 tracks failure-path defects around parent-process redirection
+Issue #49 addressed failure-path defects around parent-process redirection
 handling and `dup2()` recovery.
 
-The affected area includes:
+The affected area included:
 
 - pending redirection descriptor ownership;
 - standard-stream restoration;
 - persistent parent-process state.
 
-This is correctness work, not a post-42 feature.
+The fix closes pending descriptor ownership on failed redirection application,
+retries interrupted standard-stream restoration and terminates the persistent
+session if restoration can no longer be guaranteed.
 
 Roadmap classification:
 
     Correctness Fix
     Priority: P1
+    Status: Resolved
+
+This remains post-baseline correctness work rather than an original 42
+feature.
 
 ### #50: Literal-Dollar Allocation Failure
 
@@ -475,7 +481,8 @@ At the time this roadmap was established:
 - the professional repository baseline is documented and maintained;
 - the historical 42 state remains preserved;
 - source metadata has been normalized without rewriting history;
-- #49 and #50 are the current focused correctness follow-ups;
+- #49 has resolved the parent-redirection P1 finding;
+- #50 remains the current focused P1 correctness follow-up;
 - automated behavioural regression testing remains a useful future engineering
   direction;
 - optional post-42 capabilities remain non-committed;

--- a/docs/development/evolution-roadmap.md
+++ b/docs/development/evolution-roadmap.md
@@ -476,7 +476,7 @@ from turning into indefinite feature expansion.
 
 ## Current Direction
 
-At the time this roadmap was established:
+At the current maintained state:
 
 - the professional repository baseline is documented and maintained;
 - the historical 42 state remains preserved;

--- a/docs/development/release-strategy.md
+++ b/docs/development/release-strategy.md
@@ -503,7 +503,7 @@ This release strategy does not:
 
 ## Current Release State
 
-At the time this strategy was established:
+At the current maintained state:
 
 - `portfolio-baseline-2026-08` is the only existing tag;
 - it is an annotated historical tag;

--- a/docs/development/release-strategy.md
+++ b/docs/development/release-strategy.md
@@ -274,16 +274,17 @@ There is no exception to that rule for the first maintained release.
 
 ## Current P1 Release Gates
 
-The current evolution roadmap identifies two P1 correctness issues.
+The evolution roadmap identified two P1 correctness issues. One has now been
+resolved and one remains open.
 
 ### #49 Parent Redirection Recovery
 
-Issue #49 covers demonstrated parent-process redirection failure-path defects,
-including descriptor ownership and standard-stream restoration.
+Issue #49 resolves the demonstrated parent-process redirection failure-path
+defects involving descriptor ownership and standard-stream restoration.
 
 Release policy:
 
-    BLOCKS v1.0.0
+    RESOLVED FOR v1.0.0
 
 ### #50 Literal-Dollar Allocation Failure
 
@@ -294,8 +295,8 @@ Release policy:
 
     BLOCKS v1.0.0
 
-Both issues should be resolved and validated before the first maintained
-release is created.
+Issue #49 has satisfied its correctness gate. Issue #50 must still be resolved
+and validated before the first maintained release is created.
 
 ## Final Portfolio Audit Gate
 
@@ -508,7 +509,7 @@ At the time this strategy was established:
 - it is an annotated historical tag;
 - no semantic-version maintained release exists;
 - `main` is the current maintained development baseline;
-- #49 remains an open P1 correctness gate;
+- #49 has resolved its P1 correctness gate;
 - #50 remains an open P1 correctness gate;
 - the final portfolio audit has not yet established release readiness;
 - `v1.0.0` must therefore not be created yet.

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -310,7 +310,7 @@ int		exe_redir_one(t_redir *r, int *in_fd,
 			int *out_fd, int *status);
 int		exe_redir_dup(int fd, int std_fd, int *status);
 void	exe_redir_close(int in_fd, int out_fd);
-int		exe_redir_only(t_cmd *cmd);
+int		exe_redir_only(t_cmd *cmd, t_shell *shell);
 int		exe_heredoc_setup(const char *delim, int *fd,
 			t_child_ctx *ctx, int *status);
 int		exe_heredoc_read(int write_fd, const char *delim);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -303,6 +303,9 @@ int		exe_heredocs_prepare(t_cmd *cmd, t_child_ctx *ctx, int *status);
  * @param status Output status updated when a redirection operation fails.
  * @return 0 on success, 1 on failure.
  *
+ * Redirection descriptors transferred from t_redir nodes are consumed before
+ * return, including pending descriptors on failure paths.
+ *
  * On success, STDIN_FILENO and/or STDOUT_FILENO may have been replaced.
  */
 int		exe_redir_apply(t_cmd *cmd, int *status);
@@ -332,8 +335,11 @@ int		exe_stdio_save(int *stdin_save, int *stdout_save);
 /**
  * @brief Restore standard input and output from saved descriptors.
  *
- * Both saved descriptors are closed before the function returns, including
- * when a dup2() operation fails. This function therefore consumes them.
+ * Interrupted dup2() operations are retried. Restoration of both streams is
+ * attempted even when one restore fails.
+ *
+ * Both saved descriptors are closed before the function returns, so this
+ * function consumes them on every path.
  *
  * @param stdin_save Saved standard-input descriptor.
  * @param stdout_save Saved standard-output descriptor.

--- a/src/builtins/parent.c
+++ b/src/builtins/parent.c
@@ -13,11 +13,15 @@ int	blt_execute_parent(t_cmd *cmd, t_shell *shell)
 		return (1);
 	if (exe_redir_apply(cmd, &status))
 	{
-		exe_stdio_restore(stdin_save, stdout_save);
+		if (exe_stdio_restore(stdin_save, stdout_save))
+			shell->should_exit = 1;
 		return (status);
 	}
 	status = blt_execute(cmd, shell);
 	if (exe_stdio_restore(stdin_save, stdout_save))
+	{
+		shell->should_exit = 1;
 		return (1);
+	}
 	return (status);
 }

--- a/src/exec/command_simple.c
+++ b/src/exec/command_simple.c
@@ -15,7 +15,7 @@ int	exe_simple(t_cmd *cmd, t_shell *shell, t_token *tokens)
 	if (exe_redir_prepare(cmd, &ctx, &status))
 		return (status);
 	if (cmd->argc == 0)
-		return (exe_redir_only(cmd));
+		return (exe_redir_only(cmd, shell));
 	if (blt_is_builtin(cmd->argv[0]))
 		return (blt_execute_parent(cmd, shell));
 	pid = fork();

--- a/src/exec/redir_apply.c
+++ b/src/exec/redir_apply.c
@@ -46,7 +46,10 @@ int	exe_redir_apply(t_cmd *cmd, int *status)
 	if (apply_all_redirs(cmd->redirs, &in_fd, &out_fd, status))
 		return (1);
 	if (in_fd != -1 && exe_redir_dup(in_fd, STDIN_FILENO, status))
+	{
+		exe_redir_close(-1, out_fd);
 		return (1);
+	}
 	if (out_fd != -1
 		&& exe_redir_dup(out_fd, STDOUT_FILENO, status))
 		return (1);

--- a/src/exec/redir_only.c
+++ b/src/exec/redir_only.c
@@ -1,6 +1,6 @@
 #include "minishell.h"
 
-int	exe_redir_only(t_cmd *cmd)
+int	exe_redir_only(t_cmd *cmd, t_shell *shell)
 {
 	int	stdin_save;
 	int	stdout_save;
@@ -13,10 +13,14 @@ int	exe_redir_only(t_cmd *cmd)
 		return (1);
 	if (exe_redir_apply(cmd, &status))
 	{
-		exe_stdio_restore(stdin_save, stdout_save);
+		if (exe_stdio_restore(stdin_save, stdout_save))
+			shell->should_exit = 1;
 		return (status);
 	}
 	if (exe_stdio_restore(stdin_save, stdout_save))
+	{
+		shell->should_exit = 1;
 		return (1);
+	}
 	return (status);
 }

--- a/src/exec/stdio_backup.c
+++ b/src/exec/stdio_backup.c
@@ -16,21 +16,30 @@ int	exe_stdio_save(int *stdin_save, int *stdout_save)
 	return (0);
 }
 
+static int	restore_fd(int saved_fd, int std_fd)
+{
+	int	result;
+
+	result = dup2(saved_fd, std_fd);
+	while (result < 0 && errno == EINTR)
+		result = dup2(saved_fd, std_fd);
+	if (result < 0)
+	{
+		perror("dup2");
+		return (1);
+	}
+	return (0);
+}
+
 int	exe_stdio_restore(int stdin_save, int stdout_save)
 {
 	int	status;
 
 	status = 0;
-	if (dup2(stdin_save, STDIN_FILENO) < 0)
-	{
-		perror("dup2");
+	if (restore_fd(stdin_save, STDIN_FILENO))
 		status = 1;
-	}
-	if (dup2(stdout_save, STDOUT_FILENO) < 0)
-	{
-		perror("dup2");
+	if (restore_fd(stdout_save, STDOUT_FILENO))
 		status = 1;
-	}
 	close(stdin_save);
 	close(stdout_save);
 	return (status);


### PR DESCRIPTION
## Summary

Hardens persistent parent-process redirection recovery around `dup2()` failure
paths.

This resolves the two demonstrated descriptor and standard-stream recovery
defects recorded by the code-quality audit and tracked by #49.

Closes #49.

## Problem

The implementation had two related parent-process failure-path defects.

### Pending redirection descriptor

`exe_redir_apply()` resolves the final input and output descriptors before
applying them.

If both were pending and applying the input descriptor failed:

    input fd  -> consumed by exe_redir_dup()
    output fd -> remained open

Ownership of the output descriptor had already been transferred away from its
`t_redir` node, so the persistent shell process could leak it.

### Standard-stream restoration

Parent builtins and redirection-only commands save `STDIN_FILENO` and
`STDOUT_FILENO` before temporarily replacing them.

If restoration through `dup2()` failed, the shell could continue even though
its standard-stream state could no longer be guaranteed.

The restoration result was also ignored when redirection application itself
had already failed.

## Runtime changes

### Redirection descriptor ownership

When applying the input redirection fails, any still-pending output descriptor
is explicitly closed before returning.

This preserves the ownership invariant that descriptors transferred from
`t_redir` nodes are consumed on every return path.

### Standard-stream restoration

Restoration now:

- retries `dup2()` when interrupted by `EINTR`;
- still attempts restoration of the second stream if the first fails;
- consumes both saved descriptors exactly once;
- reports failure when either standard stream cannot be restored.

### Persistent-shell recovery policy

Both parent execution paths now treat unrecoverable standard-stream restoration
as fatal to the persistent session:

- `blt_execute_parent()`;
- `exe_redir_only()`.

When restoration cannot be guaranteed:

    shell->should_exit = 1

The normal session lifecycle then performs command/token cleanup before the
prompt loop terminates.

No abrupt `exit()` was introduced.

## Interface change

`exe_redir_only()` now receives the shell state:

    int exe_redir_only(t_cmd *cmd, t_shell *shell);

This allows the redirection-only parent path to apply the same unrecoverable
restoration policy as parent builtins.

## Failure-path validation

Temporary test harnesses outside the repository injected controlled `dup2()`
failures.

Validated cases:

- failed input `dup2()` closes the still-pending output descriptor;
- transferred redirection descriptors are no longer node-owned;
- `EINTR` during stdin restoration is retried successfully;
- permanent stdin restoration failure still attempts stdout restoration;
- permanent stdout restoration failure is propagated;
- saved standard-stream descriptors are consumed after restoration attempts;
- parent builtin restoration failure marks the session for termination;
- redirection-only restoration failure marks the session for termination;
- parent builtin success behaviour remains unchanged;
- redirection-only success behaviour remains unchanged.

Harness result:

    fd recovery:   0
    parent policy: 0

The temporary harnesses and executables were created under `/tmp` and no test
artefacts were added to the repository.

## Build validation

Reference build:

    status:   0
    warnings: 0
    errors:   0

Clang supplemental build:

    status:   0
    warnings: 0
    errors:   0

Doxygen:

    status:   0
    warnings: 0

Additional validation:

- `git diff --check` passes;
- working tree is clean;
- generated Doxygen output remains ignored;
- `portfolio-baseline-2026-08` remains unchanged at
  `7ba2005223e263964bf8ae3069da9ff54c2c2c2b`;
- no new Git tags are introduced.

## Norminette note

Norminette is not used as a gate for this change.

The maintained C files are currently rejected because the repository
deliberately removed the legacy mandatory 42 file banners during the
post-baseline source-metadata cleanup.

`include/minishell.h` also triggers a Norminette parser error at line 184, but
that exact line and parser failure already exist on `main`; the #49 header
change does not introduce it.

Compiler, runtime failure-injection and documentation validation are therefore
the relevant checks for this focused fix.

## Documentation

Updated maintained documentation records that:

- Q48-R1 is resolved by #49;
- Q48-R3 is resolved by #49;
- descriptor ownership is closed on failure paths;
- interrupted restoration is retried;
- unrecoverable persistent-shell restoration terminates the session;
- #49 has satisfied its P1 release gate;
- #50 remains the outstanding P1 correctness gate.

## Release impact

This PR resolves one blocker for the first maintained portfolio release:

    #49  RESOLVED FOR v1.0.0
    #50  BLOCKS v1.0.0

`v1.0.0` must still not be created until #50 is resolved and the final
portfolio audit establishes release readiness.