### PR TITLE
fix(expand): propagate literal-dollar allocation failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,10 +565,11 @@ The repository now distinguishes explicitly between the preserved historical
 The post-baseline evolution policy is defined in
 [`docs/development/evolution-roadmap.md`](docs/development/evolution-roadmap.md).
 
-Post-baseline correctness work currently includes:
+Post-baseline P1 correctness work identified by the implementation audit has
+been resolved through:
 
-- resolved issue #49 for parent-process redirection recovery;
-- open issue #50 for literal-dollar allocation-error propagation.
+- issue #49 for parent-process redirection recovery;
+- issue #50 for literal-dollar allocation-error propagation.
 
 These fixes remain distinguishable from documentation-only modernization work.
 
@@ -576,8 +577,8 @@ The maintained release strategy is now defined separately from the historical
 baseline.
 
 The first maintained `v1.0.0` release is intentionally not created yet.
-Issue #49 has resolved one P1 correctness gate. Issue #50 remains open, and the
-final portfolio audit must still establish release readiness.
+Issues #49 and #50 have resolved the identified P1 correctness gates. The final
+portfolio audit must still establish release readiness.
 
 Broader automated regression testing, further maintenance improvements and
 optional post-42 technical exploration remain possible future directions rather

--- a/docs/development/code-quality.md
+++ b/docs/development/code-quality.md
@@ -684,8 +684,8 @@ The audited memory model is generally explicit and stable:
   allocation succeeds;
 - child cleanup operates only on the child's post-`fork()` address space.
 
-The demonstrated allocation-propagation defect is isolated to the
-literal-dollar expansion path and is tracked separately in #50.
+The demonstrated allocation-propagation defect was isolated to the
+literal-dollar expansion path and has been resolved by #50.
 
 ## Finding Classification
 

--- a/docs/development/code-quality.md
+++ b/docs/development/code-quality.md
@@ -536,11 +536,13 @@ For a literal `$`, the allocation failure can therefore be converted into an
 empty expansion. For input such as `$-`, the dollar can be silently dropped
 while processing continues.
 
-Follow-up:
+Resolution:
 
     #50 Propagate allocation failures during literal-dollar expansion
 
-No behaviour-changing fix is included in this audit workstream.
+Issue #50 aligns the literal-dollar allocation path with the rest of the
+expansion subsystem by setting `ERR_MALLOC` when allocation of the literal
+dollar string fails.
 
 ### `Q48-M2`: partial `cd` state update after successful `chdir()`
 
@@ -925,7 +927,7 @@ The completed code-quality audit establishes the following baseline:
 - `wait()` / `waitpid()` interruption handling: accepted trade-off;
 - interactive Readline signal-handler behaviour: plausible risk requiring
   focused future investigation;
-- literal-dollar allocation propagation defect: tracked in #50;
+- literal-dollar allocation propagation defect: resolved by #50;
 - partial `cd` state after post-`chdir()` failure: plausible risk;
 - transient dangling pointers during failure unwind: accepted trade-off;
 - token, grammar, environment and child-process memory ownership: no

--- a/docs/development/evolution-roadmap.md
+++ b/docs/development/evolution-roadmap.md
@@ -94,7 +94,8 @@ They should:
 - include appropriate validation;
 - update documentation when a maintained contract changes.
 
-Known correctness work includes the resolved #49 follow-up and the remaining #50 follow-up.
+Known P1 correctness work identified by the audit has now been resolved through
+#49 and #50.
 
 ### Maintenance and Reliability
 
@@ -262,7 +263,7 @@ Examples include:
 - missing allocation-error propagation;
 - incorrect status or state handling.
 
-Issue #49 has been resolved from this correctness queue; #50 remains current P1 work.
+Issues #49 and #50 have both been resolved from this P1 correctness queue.
 
 Their exact implementation order may be chosen independently, but they should
 normally precede optional post-42 feature work.
@@ -324,17 +325,21 @@ feature.
 
 ### #50: Literal-Dollar Allocation Failure
 
-Issue #50 tracks missing `ERR_MALLOC` propagation when allocation of a literal
-dollar expansion fails.
+Issue #50 addressed missing `ERR_MALLOC` propagation when allocation of a
+literal dollar expansion fails.
 
-This is a narrow error-propagation defect.
+The fix aligns this path with the existing expansion allocation contract:
+allocation failure now sets `ERR_MALLOC`, causes variable expansion to fail and
+propagates through the scanner instead of silently dropping the literal dollar.
 
 Roadmap classification:
 
     Correctness Fix
     Priority: P1
+    Status: Resolved
 
-Neither fix is implemented by this roadmap workstream.
+Neither #49 nor #50 was implemented by this roadmap workstream itself. Both
+were resolved later through focused technical issues.
 
 ## Known Risks That Are Not Current Commitments
 
@@ -482,7 +487,8 @@ At the current maintained state:
 - the historical 42 state remains preserved;
 - source metadata has been normalized without rewriting history;
 - #49 has resolved the parent-redirection P1 finding;
-- #50 remains the current focused P1 correctness follow-up;
+- #50 has resolved the literal-dollar allocation P1 finding;
+- no demonstrated P1 correctness finding from the audit remains open;
 - automated behavioural regression testing remains a useful future engineering
   direction;
 - optional post-42 capabilities remain non-committed;

--- a/docs/development/release-strategy.md
+++ b/docs/development/release-strategy.md
@@ -274,8 +274,8 @@ There is no exception to that rule for the first maintained release.
 
 ## Current P1 Release Gates
 
-The evolution roadmap identified two P1 correctness issues. One has now been
-resolved and one remains open.
+The evolution roadmap identified two P1 correctness issues. Both have now been
+resolved.
 
 ### #49 Parent Redirection Recovery
 
@@ -288,15 +288,15 @@ Release policy:
 
 ### #50 Literal-Dollar Allocation Failure
 
-Issue #50 covers missing allocation-error propagation in the literal-dollar
+Issue #50 resolves missing allocation-error propagation in the literal-dollar
 expansion path.
 
 Release policy:
 
-    BLOCKS v1.0.0
+    RESOLVED FOR v1.0.0
 
-Issue #49 has satisfied its correctness gate. Issue #50 must still be resolved
-and validated before the first maintained release is created.
+Both identified P1 correctness gates have now been satisfied. The final
+portfolio audit remains a prerequisite for the first maintained release.
 
 ## Final Portfolio Audit Gate
 
@@ -510,7 +510,8 @@ At the current maintained state:
 - no semantic-version maintained release exists;
 - `main` is the current maintained development baseline;
 - #49 has resolved its P1 correctness gate;
-- #50 remains an open P1 correctness gate;
+- #50 has resolved its P1 correctness gate;
+- no identified P1 correctness release gate remains open;
 - the final portfolio audit has not yet established release readiness;
 - `v1.0.0` must therefore not be created yet.
 

--- a/src/expand/variables.c
+++ b/src/expand/variables.c
@@ -26,7 +26,12 @@ static char	*expand_dollar_value(const char *str, size_t *i,
 	if (part || *err != ERR_NONE)
 		return (part);
 	if (!exp_name_start(str[*i]))
-		return (ft_strdup("$"));
+	{
+		part = ft_strdup("$");
+		if (!part)
+			*err = ERR_MALLOC;
+		return (part);
+	}
 	start = *i;
 	while (exp_name_char(str[*i]))
 		(*i)++;


### PR DESCRIPTION
## Summary

Propagates allocation failure correctly when variable expansion needs to
preserve a literal dollar sign.

This resolves the demonstrated expansion error-propagation defect recorded as
Q48-M1 by the implementation-quality audit and tracked by #50.

Closes #50.

## Problem

`expand_dollar_value()` preserves `$` literally when the character following
it is not a valid variable-name start.

The previous implementation returned the allocation directly:

    if (!exp_name_start(str[*i]))
        return (ft_strdup("$"));

If that allocation failed:

    ft_strdup("$") -> NULL

the function returned `NULL` while leaving the shared error state as:

    ERR_NONE

`exp_variables()` could therefore interpret the result as ordinary expansion
progress instead of an allocation failure.

For input such as:

    $-

the literal dollar could consequently be dropped silently while scanning
continued.

## Runtime fix

The literal-dollar path now follows the same allocation contract already used
throughout the expansion subsystem:

    part = ft_strdup("$");

    if allocation fails:
        *err = ERR_MALLOC

    return part

This means allocation failure now propagates through:

    expand_dollar_value()
            |
            v
      ERR_MALLOC + NULL
            |
            v
       exp_variables()
            |
            v
          scanner

instead of being mistaken for successful expansion.

## Scope

The runtime change is deliberately narrow.

Only:

    src/expand/variables.c

contains runtime modifications.

No scanner interface, expansion API, environment handling, quoting logic or
other runtime subsystem is changed.

## Failure-injection validation

A temporary harness outside the repository intercepted `ft_strdup()` and
forced failure specifically on allocation of the literal dollar string.

For:

    exp_variables("$-")

the harness allowed:

    ft_strdup("") -> success

and forced:

    ft_strdup("$") -> NULL

The corrected behaviour was verified as:

    ERR_MALLOC
        |
        v
    exp_variables() == NULL
        |
        v
    scanner propagates ERR_MALLOC

Validated failure cases:

- literal-dollar allocation failure sets `ERR_MALLOC`;
- variable expansion returns `NULL`;
- `scn_word()` propagates the allocation failure instead of accepting a
  partial result.

Harness result:

    status: 0

No temporary harness or executable was added to the repository.

## Success-path validation

Normal expansion behaviour was also verified:

    "$"          -> "$"
    "$-"         -> "$-"
    "abc$-xyz"   -> "abc$-xyz"
    "$$"         -> "$$"
    "$?"         -> "42"
    "$VAR"       -> "value"
    "$UNSET"     -> ""

This confirms that the fix changes only the allocation-failure path.

## Build validation

Reference build:

    status:   0
    warnings: 0
    errors:   0

Clang supplemental build:

    status:   0
    warnings: 0
    errors:   0

Doxygen:

    status:   0
    warnings: 0

Additional checks:

- `git diff --check` passes;
- working tree is clean;
- no unrelated runtime files changed;
- generated Doxygen output remains ignored;
- no temporary test artefacts are versioned.

## Documentation

Maintained documentation now records that:

- Q48-M1 is resolved by #50;
- literal-dollar allocation failure follows the existing `ERR_MALLOC`
  propagation contract;
- #50 is resolved in the evolution roadmap;
- #50 has satisfied its `v1.0.0` correctness gate;
- both identified P1 correctness gates are now resolved;
- the final portfolio audit remains required before release.

Historical wording describing how the original quality audit split #49 and #50
into focused follow-up issues is intentionally preserved.

The release-strategy non-goals also continue to state that the release-strategy
workstream itself did not implement #49 or #50.

## Release impact

After this change:

    #49  RESOLVED FOR v1.0.0
    #50  RESOLVED FOR v1.0.0

No identified P1 correctness release gate remains open.

This does not create `v1.0.0`.

The final portfolio audit and release-candidate validation must still establish
release readiness before the first maintained release is tagged.

## Historical baseline

`portfolio-baseline-2026-08` remains unchanged at:

    7ba2005223e263964bf8ae3069da9ff54c2c2c2b

No new Git tag or GitHub Release is introduced by this PR.