### PR TITLE
docs(audit): complete final portfolio readiness audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,8 +580,12 @@ The maintained release strategy is now defined separately from the historical
 baseline.
 
 The first maintained `v1.0.0` release is intentionally not created yet.
-Issues #49 and #50 have resolved the identified P1 correctness gates. The final
-portfolio audit must still establish release readiness.
+Issues #49 and #50 have resolved the identified P1 correctness gates, and the
+final portfolio audit has established readiness to proceed to release-candidate
+validation.
+
+The audit evidence and verdict are recorded in
+[`docs/development/final-portfolio-audit.md`](docs/development/final-portfolio-audit.md).
 
 Broader automated regression testing, further maintenance improvements and
 optional post-42 technical exploration remain possible future directions rather

--- a/README.md
+++ b/README.md
@@ -539,7 +539,10 @@ history.
 ## Project History
 
 This project was originally developed collaboratively by a two-person team
-during the 42 Porto Common Core.
+during the 42 Porto Common Core:
+
+- Luís Quental Almeida;
+- João da Silva (`@xSilverWasHere`).
 
 The Git history and original contributor attribution are intentionally
 preserved.

--- a/docs/README.md
+++ b/docs/README.md
@@ -115,13 +115,16 @@ The maintained repository now includes:
 - current architecture and runtime-flow documentation;
 - engineering decision records;
 - contribution and Git workflow documentation;
-- maintained testing strategy and manual validation guidance.
+- maintained testing strategy and manual validation guidance;
+- continuous-integration and compiler-diversity quality documentation;
+- static-analysis evaluation and implementation-quality audit records;
+- Doxygen and maintained API-documentation guidance;
+- post-baseline evolution policy and maintained release strategy.
 
-Further work is tracked separately for areas including:
+Further work may include:
 
-- automated regression testing and broader CI quality gates;
-- static-analysis automation;
-- API documentation where it adds value.
+- automated behavioural regression testing and broader quality automation;
+- additional static-analysis automation where future evidence justifies it.
 
 Historical material remains available under [`history/`](history/) as evidence
 and context while current documentation evolves independently.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -27,6 +27,8 @@ For contributors and maintainers beginning from the repository root:
   preserved historical baseline.
 - [`release-strategy.md`](release-strategy.md) defines historical-reference,
   maintained-version and portfolio-release policy.
+- [`final-portfolio-audit.md`](final-portfolio-audit.md) records the final
+  repository-wide portfolio-readiness evidence and verdict.
 - [`api-documentation.md`](api-documentation.md) defines the maintained
   API-documentation boundary, documentation conventions and Doxygen strategy.
 

--- a/docs/development/evolution-roadmap.md
+++ b/docs/development/evolution-roadmap.md
@@ -466,8 +466,11 @@ such as:
 The P1 correctness work identified by the implementation audit has been
 resolved through #49 and #50.
 
-The first maintained release is now gated by the final portfolio audit and the
-subsequent release-candidate validation defined by the release strategy.
+The final portfolio audit has established readiness to proceed to the
+release-candidate validation defined by the release strategy.
+
+The first maintained release remains gated by successful completion of that
+validation.
 
 This roadmap determines how future work is categorized and prioritized.
 

--- a/docs/development/evolution-roadmap.md
+++ b/docs/development/evolution-roadmap.md
@@ -367,10 +367,15 @@ value justifies work.
 The maintained README and architecture documentation explicitly describe
 features that are not present in the current implementation.
 
-Examples include optional shell grammar and heredoc-body variable expansion.
+Examples include optional shell grammar and the documented heredoc-body
+variable-expansion limitation.
 
-Documenting a missing capability does not create a requirement to implement
-it.
+The preserved v10.0 subject requires heredoc input, environment-variable
+expansion and `$?` expansion, but does not explicitly define expansion
+semantics for heredoc body lines or quoted heredoc delimiters.
+
+The current audit therefore does not classify the missing heredoc-body
+expansion behaviour as a demonstrated P0 or P1 correctness defect.
 
 If such functionality is added later, it should be identified explicitly as
 post-baseline development and validated independently from the historical 42
@@ -458,8 +463,11 @@ such as:
 
     v1.0.0
 
-The first maintained release is intentionally gated by unresolved P1
-correctness work and the final portfolio audit.
+The P1 correctness work identified by the implementation audit has been
+resolved through #49 and #50.
+
+The first maintained release is now gated by the final portfolio audit and the
+subsequent release-candidate validation defined by the release strategy.
 
 This roadmap determines how future work is categorized and prioritized.
 

--- a/docs/development/final-portfolio-audit.md
+++ b/docs/development/final-portfolio-audit.md
@@ -1,0 +1,507 @@
+# Final Portfolio Audit
+
+## Status
+
+    Complete
+
+Audit issue:
+
+    #60 Perform final portfolio audit and establish release readiness
+
+Audit date:
+
+    2026-08-31
+
+Historical reference:
+
+    portfolio-baseline-2026-08
+
+Maintained branch audited from:
+
+    f7437d6 fix(expand): propagate literal-dollar allocation failure (#59)
+
+## Verdict
+
+    READY FOR RELEASE-CANDIDATE VALIDATION
+
+This verdict does not create or authorize the `v1.0.0` tag by itself.
+
+It establishes that the audited repository state is ready to proceed to the
+release-candidate validation defined by the maintained release strategy.
+
+## Objective
+
+The final portfolio audit evaluates whether the repository is internally
+consistent, technically validated and suitable to present as the maintained
+portfolio state before the first semantic-version release.
+
+The audit covers:
+
+- repository and Git provenance;
+- tracked-file and generated-artifact hygiene;
+- maintained documentation consistency;
+- reference and compiler-diversity builds;
+- CI and Doxygen configuration;
+- previously identified code-quality findings;
+- non-interactive and interactive runtime behaviour;
+- public portfolio presentation;
+- release-gate consistency.
+
+The audit does not claim that the implementation is defect-free.
+
+It records the evidence obtained, the known limitations and whether any known
+demonstrated issue currently blocks progression toward the first maintained
+release.
+
+## Scope Boundary
+
+Issue #60 is an audit and documentation workstream.
+
+No runtime implementation change is introduced by the audit branch.
+
+Demonstrated runtime defects discovered during this process would require
+focused technical issues rather than being silently mixed into the audit.
+
+## Phase A: Repository and Git Provenance
+
+Result:
+
+    PASS
+
+Evidence established during the audit:
+
+- the audit branch started from the same commit as `main` and `origin/main`;
+- the maintained base commit was `f7437d6`;
+- `portfolio-baseline-2026-08` remains the only historical baseline tag;
+- the historical tag is annotated;
+- the tag resolves to the preserved pre-modernization commit;
+- no semantic-version release tag existed when the audit began;
+- Git history after the historical baseline remains linear through the
+  maintained squash-merge workflow;
+- the repository remote points to `LuisQAlmeida/42Minishell`;
+- the worktree was clean at the provenance checkpoint.
+
+The historical baseline remains immutable and distinct from later portfolio
+maintenance.
+
+## Phase B: Repository Structure and Hygiene
+
+Result:
+
+    PASS
+
+The repository contained 226 tracked files at the structure checkpoint.
+
+The maintained C implementation inventory was:
+
+- 51 C files under `src/`;
+- 18 C files under `libft/`;
+- 69 maintained C source files in total;
+- 2 maintained headers.
+
+The Git-tracked source inventory matched the filesystem inventory.
+
+The audit found:
+
+- no tracked build output;
+- no tracked generated Doxygen output;
+- no tracked backup or temporary files;
+- no obvious secret-like filenames;
+- no machine-specific absolute paths;
+- no tracked executable files;
+- no tracked symbolic links;
+- no remaining legacy 42 source banners in the maintained C/header tree.
+
+Historical `.agents` and related BMAD/project tooling were verified as
+pre-existing project material rather than portfolio-modernization debris.
+
+They remain preserved as historical project tooling.
+
+## Phase C: Documentation Consistency
+
+Result:
+
+    PASS AFTER CORRECTION
+
+The documentation audit initially inspected 143 tracked Markdown files and 158
+local Markdown links.
+
+No broken local-link target was found.
+
+Maintained documentation correctly distinguishes:
+
+- current implementation documentation;
+- engineering decisions;
+- development and maintenance policy;
+- testing and validation guidance;
+- historical project material.
+
+Two stale documentation areas were corrected during #60:
+
+1. the documentation index was updated to reflect already-established CI,
+   quality, API/Doxygen, roadmap and release documentation;
+2. the static-analysis documentation was updated to distinguish the historical
+   pre-banner-removal Norminette result from the current maintained tree.
+
+Later audit evidence also required release-readiness wording in the evolution
+roadmap to be reconciled with the resolved #49 and #50 correctness issues.
+
+## Phase D: Build, CI Contract and Doxygen
+
+Result:
+
+    PASS
+
+Reference build:
+
+- clean build succeeded;
+- compiler warnings: 0;
+- compiler errors: 0;
+- expected executable produced;
+- unchanged second `make` did not relink.
+
+Clang compiler-diversity build:
+
+- clean build succeeded;
+- compiler warnings: 0;
+- compiler errors: 0;
+- expected executable produced;
+- unchanged second `make CC=clang` did not relink.
+
+Audited compiler identities were:
+
+    cc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0
+    Ubuntu clang version 18.1.3 (1ubuntu1)
+
+Doxygen:
+
+- generation status: success;
+- warnings: 0;
+- errors: 0;
+- HTML output generated;
+- generated output ignored;
+- generated Doxygen files tracked by Git: 0.
+
+The audit branch did not modify:
+
+- `Makefile`;
+- `libft/Makefile`;
+- `Doxyfile`;
+- `.github/workflows/ci.yml`.
+
+The maintained CI contract continues to provide:
+
+- `CI / build`;
+- `CI / quality`;
+- Ubuntu 24.04 reference execution;
+- reference build validation;
+- Clang compiler-diversity validation;
+- executable checks;
+- no-relink checks.
+
+Remote CI execution for the final audit branch remains part of pull-request
+release-candidate validation rather than local Phase D evidence.
+
+## Phase E: Code-Quality Findings
+
+Result:
+
+    PASS AFTER CORRECTION
+
+The implementation-quality audit findings were reconciled against their
+current state.
+
+### Demonstrated defects
+
+`Q48-R1`:
+
+    pending redirection descriptor after failed input dup2()
+
+Classification:
+
+    DEFECT
+
+Resolution:
+
+    #49 resolved
+
+`Q48-R3`:
+
+    unrecoverable parent standard-stream restoration failure
+
+Classification:
+
+    DEFECT
+
+Resolution:
+
+    #49 resolved
+
+`Q48-M1`:
+
+    literal-dollar allocation failure not propagated
+
+Classification:
+
+    DEFECT
+
+Resolution:
+
+    #50 resolved
+
+### Accepted or non-demonstrated findings
+
+`Q48-R2`:
+
+    ACCEPTED_TRADEOFF
+
+Explicit `wait()` / `waitpid()` EINTR retry handling remains a documented
+trade-off without a demonstrated current runtime defect.
+
+`Q48-R4`:
+
+    PLAUSIBLE_RISK
+
+Interactive Readline operations from the signal handler remain documented for
+future investigation without a demonstrated runtime failure.
+
+`Q48-M2`:
+
+    PLAUSIBLE_RISK
+
+Partial maintained environment-state update after a successful `chdir()`
+followed by later failure remains documented without a demonstrated normal-path
+runtime defect.
+
+`Q48-M3`:
+
+    ACCEPTED_TRADEOFF
+
+Transient dangling pointers during immediate failure unwind remain accepted
+because no subsequent dereference, double free or current use-after-free was
+identified.
+
+The GCC analyzer descriptor findings remain classified as analyzer
+limitations.
+
+The Clang `ft_memcpy()` finding remains an accepted trade-off under the
+maintained call contract.
+
+The duplicated wait-status helpers remain accepted duplication.
+
+At completion of this audit:
+
+    known open P0 findings: 0
+    known open P1 findings: 0
+
+### Heredoc Expansion
+
+The maintained implementation writes heredoc body lines verbatim and therefore
+does not expand `$VAR` or `$?` inside heredoc bodies.
+
+The preserved Minishell v10.0 subject explicitly requires:
+
+- `<<` heredoc input until a delimiter;
+- environment-variable expansion;
+- `$?` expansion.
+
+The preserved subject does not explicitly define expansion semantics for
+heredoc body lines or quoted heredoc delimiters.
+
+The audit therefore does not classify the current heredoc-body expansion
+limitation as a demonstrated P0 or P1 correctness defect.
+
+The limitation remains explicitly documented.
+
+## Phase F: Runtime Regression
+
+Result:
+
+    PASS
+
+The final audit performed two temporary runtime regression harnesses outside the
+repository.
+
+### Non-Interactive Matrix
+
+Result:
+
+    32 / 32 PASS
+
+The matrix covered:
+
+- external commands;
+- built-in execution;
+- persistent `cd`;
+- persistent `export`;
+- persistent `unset`;
+- single-quote behaviour;
+- double-quote expansion;
+- missing-variable expansion;
+- literal-dollar handling;
+- command-not-found status and diagnostics;
+- two-stage pipelines;
+- three-stage pipelines;
+- pipeline final-command status;
+- input redirection;
+- output redirection;
+- append redirection;
+- combined redirections;
+- parent built-in redirection;
+- parent stdout restoration;
+- redirection-only commands;
+- stdout restoration after redirection-only execution;
+- basic heredoc execution;
+- documented verbatim heredoc behaviour;
+- missing-input failure handling;
+- shell recovery after missing input;
+- syntax-error status;
+- shell recovery after syntax error;
+- numeric `exit` status propagation.
+
+### Interactive PTY and Signal Matrix
+
+Result:
+
+    11 / 11 PASS
+
+The PTY-based checks covered:
+
+- `Ctrl-C` at the interactive prompt;
+- prompt `SIGINT` status 130;
+- `Ctrl-\` at the interactive prompt;
+- `Ctrl-C` during a foreground child;
+- foreground `SIGINT` status 130;
+- `Ctrl-\` during a foreground child;
+- foreground `SIGQUIT` status 131;
+- `Ctrl-C` during heredoc;
+- interrupted-heredoc status 130;
+- `Ctrl-D` at an empty prompt;
+- successful exit from a fresh prompt through `Ctrl-D`.
+
+Combined runtime result:
+
+    43 / 43 PASS
+
+The temporary audit harnesses remained under `/tmp` and were not added to the
+repository.
+
+## Phase G: Portfolio Presentation
+
+Result:
+
+    PASS AFTER CORRECTION
+
+The public repository presentation was reviewed from the perspective of an
+external developer or technical reviewer.
+
+GitHub repository state at the audit checkpoint:
+
+- visibility: public;
+- default branch: `main`;
+- repository archived: no;
+- repository fork: no;
+- license recognized by GitHub: MIT;
+- maintained releases: none;
+- tags: `portfolio-baseline-2026-08` only.
+
+The repository description communicates the shell's implementation scope,
+including input processing, expansion, pipelines, redirections, heredocs,
+built-ins, path resolution and signals.
+
+Repository topics cover the relevant C, Unix, systems-programming, shell,
+process, pipe, file-descriptor, Readline and signal domains.
+
+The root README provides discoverable entry points for:
+
+- project purpose;
+- architecture;
+- runtime flow;
+- core data model;
+- supported features;
+- build instructions;
+- engineering highlights;
+- testing and validation;
+- CI;
+- current limitations;
+- maintained documentation;
+- project history;
+- future evolution;
+- license.
+
+All audited local README link targets existed.
+
+### Original Collaboration
+
+Historical Git evidence confirms substantial original contribution from both
+members of the two-person project team.
+
+The README was corrected during #60 to name the original collaborators
+explicitly:
+
+- Luís Quental Almeida;
+- João da Silva (`@xSilverWasHere`).
+
+Historical Git authorship remains untouched.
+
+The existing MIT license also predates the portfolio-modernization baseline.
+The audit does not make a retrospective legal ownership determination and does
+not rewrite the historical license notice.
+
+## Corrections Introduced by Issue #60
+
+The final audit identified documentation and presentation inconsistencies but
+did not identify a new demonstrated runtime defect.
+
+Corrections made during the audit include:
+
+- aligning the documentation index with the maintained repository state;
+- correcting current Norminette/static-analysis framing after source-banner
+  removal;
+- reconciling P1 and release-gate wording after #49 and #50;
+- documenting the evidence-based heredoc-expansion classification;
+- making the original two-person project attribution explicit in the README;
+- recording this final portfolio audit.
+
+No maintained runtime source change is part of #60.
+
+## Remaining Release-Candidate Validation
+
+This audit establishes readiness to proceed. It does not itself publish a
+release.
+
+Before creating `v1.0.0`, the maintained release workflow must still complete
+the release-candidate validation defined in `release-strategy.md`.
+
+That process includes validating the final pull request and the exact maintained
+state that will become the release candidate.
+
+The release tag must not be created from an unvalidated or different repository
+state.
+
+## Final Assessment
+
+The repository now has:
+
+- preserved historical provenance;
+- explicit distinction between original and post-baseline work;
+- coherent maintained architecture documentation;
+- documented engineering decisions;
+- documented development and contribution workflow;
+- protected pull-request integration;
+- maintained reference and Clang CI checks;
+- reproducible testing guidance;
+- documented static-analysis decisions;
+- documented resource and code-quality review;
+- Doxygen API documentation infrastructure;
+- explicit evolution and release policy;
+- no known open P0 or P1 finding from the completed quality audit;
+- successful reference and compiler-diversity builds;
+- successful Doxygen generation;
+- 43 of 43 audited runtime regression checks passing;
+- public portfolio metadata and contributor attribution consistent with the
+  preserved repository history.
+
+Final verdict:
+
+    READY FOR RELEASE-CANDIDATE VALIDATION

--- a/docs/development/release-strategy.md
+++ b/docs/development/release-strategy.md
@@ -512,8 +512,10 @@ At the current maintained state:
 - #49 has resolved its P1 correctness gate;
 - #50 has resolved its P1 correctness gate;
 - no identified P1 correctness release gate remains open;
-- the final portfolio audit has not yet established release readiness;
-- `v1.0.0` must therefore not be created yet.
+- the final portfolio audit has established readiness to proceed to
+  release-candidate validation;
+- `v1.0.0` has not yet been created and remains gated by successful completion
+  of that validation.
 
 The first maintained portfolio release becomes eligible only after its
 documented readiness gates pass.

--- a/docs/development/static-analysis.md
+++ b/docs/development/static-analysis.md
@@ -122,11 +122,14 @@ Compiler warnings are valuable but do not provide complete static analysis.
 
 ### Norminette
 
-Norminette remains relevant because Minishell originated as a 42 project and
-the historical source follows 42-style constraints.
+Norminette was relevant to the original 42 project and to the issue #44
+discovery audit.
 
-The discovery audit used Norminette 3.3.59 across the maintained C source and
-headers.
+That audit was performed before the later source-metadata cleanup removed the
+legacy 42 file banners from the maintained C/header tree.
+
+The discovery audit used Norminette 3.3.59 across the then-maintained C source
+and headers.
 
 Observed result:
 
@@ -144,10 +147,13 @@ This is a deliberate signal-handling design choice.
 Despite all files reporting `OK!`, the command returned exit status 1 because
 of the notices.
 
-For that reason, raw Norminette exit status is not currently used as an
-automated hard CI gate.
+The current maintained tree intentionally no longer contains the mandatory 42
+file banners. A repository-wide Norminette run therefore reports header
+validation failures and is not a meaningful current acceptance gate.
 
-Norminette remains useful as 42-specific manual validation where appropriate.
+The recorded issue #44 result remains evidence of the pre-cleanup 42-style
+source state. Norminette may still be useful when inspecting the historical
+baseline or when explicitly validating 42-specific constraints.
 
 ### GCC `-fanalyzer`
 
@@ -250,20 +256,26 @@ It is not part of the current baseline.
 
 ## Investigative Tool Reproduction
 
-The investigative checks evaluated during issue #44 can also be reproduced
-locally.
+The investigative commands evaluated during issue #44 are preserved below for
+traceability.
+
+Re-running them against the current maintained tree may produce different
+results where later repository work intentionally changed the audited
+conditions.
 
 ### Norminette
 
-The maintained C source and headers were checked with:
+During issue #44, the then-maintained C source and headers were checked with:
 
     norminette include src libft
 
-The audited result reported all 71 files as `OK!` together with two
+The recorded result reported all 71 files as `OK!` together with two
 `GLOBAL_VAR_DETECTED` notices for the deliberate signal-state global.
 
-Because those notices cause a non-zero command status, the raw exit code is
-not currently suitable as a hard CI gate.
+Later source-metadata cleanup deliberately removed the legacy 42 file banners.
+Running the same command against the current maintained tree therefore produces
+header-validation failures and should not be treated as a current repository
+acceptance gate.
 
 ### GCC `-fanalyzer`
 


### PR DESCRIPTION
## Summary

Completes the final repository-wide portfolio audit required before the first
maintained semantic-version release.

The audit validates repository provenance, tracked-file hygiene, documentation
consistency, build and Doxygen behaviour, previously identified quality
findings, runtime behaviour and public portfolio presentation.

It establishes the following verdict:

    READY FOR RELEASE-CANDIDATE VALIDATION

This PR does not create `v1.0.0`.

## Audit results

- Repository and Git provenance: PASS
- Repository structure and hygiene: PASS
- Documentation consistency: PASS after correction
- Reference build, CI contract and Doxygen: PASS
- Code-quality finding reconciliation: PASS after correction
- Runtime regression: PASS, 43/43 checks
- Portfolio presentation: PASS after correction
- Release-readiness assessment: PASS

## Runtime validation

The audit used temporary local harnesses outside the repository.

Non-interactive regression:

    32 / 32 PASS

Interactive PTY and signal regression:

    11 / 11 PASS

Combined result:

    43 / 43 PASS

Coverage included commands, built-ins, persistent shell state, variable
expansion, quoting, pipelines, exit status, redirections, heredocs, error
recovery, Ctrl-C, Ctrl-\, Ctrl-D and foreground-process signal behaviour.

## Quality findings

All demonstrated correctness defects identified by the implementation-quality
audit have been resolved:

- Q48-R1: resolved by #49
- Q48-R3: resolved by #49
- Q48-M1: resolved by #50

Remaining findings are documented analyzer limitations, accepted trade-offs,
accepted duplication or plausible risks without demonstrated current runtime
defects.

Current known release-gate state:

    open P0 findings: 0
    open P1 findings: 0

## Documentation corrections

This audit also:

- aligns the documentation index with the maintained repository state;
- updates the current Norminette/static-analysis framing after legacy banner
  removal;
- reconciles roadmap and release wording after #49 and #50;
- records the evidence-based heredoc-expansion classification;
- makes the original two-person project attribution explicit;
- adds the permanent final portfolio audit record.

The complete audit is documented in:

`docs/development/final-portfolio-audit.md`

## Scope

This PR introduces no runtime source changes.

It does not modify:

- `src/`
- `include/`
- `libft/`
- `Makefile`
- `libft/Makefile`
- `Doxyfile`
- `.github/workflows/ci.yml`

## Release relationship

The historical reference remains:

`portfolio-baseline-2026-08`

No semantic-version release currently exists.

Successful completion of this PR moves the repository into
release-candidate validation. The exact maintained state must still be
validated before creating `v1.0.0`.

Closes #60