### PR TITLE
docs(release): prepare v1.0.0 publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,10 +579,14 @@ These fixes remain distinguishable from documentation-only modernization work.
 The maintained release strategy is now defined separately from the historical
 baseline.
 
-The first maintained `v1.0.0` release is intentionally not created yet.
-Issues #49 and #50 have resolved the identified P1 correctness gates, and the
-final portfolio audit has established readiness to proceed to release-candidate
-validation.
+The final portfolio audit and subsequent release-candidate validation have
+completed successfully.
+
+The first maintained `v1.0.0` release has not yet been published. Release
+preparation is tracked through
+[issue #62](https://github.com/LuisQAlmeida/42Minishell/issues/62), and the exact
+final `main` state must still be validated after those preparation changes are
+integrated and before the release tag is created.
 
 The audit evidence and verdict are recorded in
 [`docs/development/final-portfolio-audit.md`](docs/development/final-portfolio-audit.md).

--- a/docs/development/evolution-roadmap.md
+++ b/docs/development/evolution-roadmap.md
@@ -466,11 +466,12 @@ such as:
 The P1 correctness work identified by the implementation audit has been
 resolved through #49 and #50.
 
-The final portfolio audit has established readiness to proceed to the
-release-candidate validation defined by the release strategy.
+The final portfolio audit and subsequent release-candidate validation have
+completed successfully.
 
-The first maintained release remains gated by successful completion of that
-validation.
+The first maintained release is now in publication preparation under #62. The
+exact final `main` state must still be validated after release-state
+documentation is integrated and before the annotated `v1.0.0` tag is created.
 
 This roadmap determines how future work is categorized and prioritized.
 
@@ -504,7 +505,8 @@ At the current maintained state:
   direction;
 - optional post-42 capabilities remain non-committed;
 - maintained release strategy is defined in `release-strategy.md`;
-- final portfolio review remains a separate closing workstream.
+- final portfolio audit and release-candidate validation are complete;
+- first maintained release publication is tracked separately through #62.
 
 The roadmap should be updated when the evolution policy itself changes, not
 merely whenever an individual issue is opened or closed.

--- a/docs/development/release-strategy.md
+++ b/docs/development/release-strategy.md
@@ -296,11 +296,13 @@ Release policy:
     RESOLVED FOR v1.0.0
 
 Both identified P1 correctness gates have now been satisfied. The final
-portfolio audit remains a prerequisite for the first maintained release.
+portfolio audit prerequisite has also been completed.
 
 ## Final Portfolio Audit Gate
 
 The final portfolio audit is also a prerequisite for `v1.0.0`.
+
+That prerequisite has now been satisfied.
 
 Its purpose is different from the correctness gates.
 
@@ -325,6 +327,15 @@ Therefore the first maintained release sequence is:
             |
             v
     validate release candidate on main
+            |
+            v
+    reconcile release-state documentation
+            |
+            v
+    integrate release preparation through PR + CI
+            |
+            v
+    validate exact final main state
             |
             v
     create annotated v1.0.0 tag
@@ -512,10 +523,13 @@ At the current maintained state:
 - #49 has resolved its P1 correctness gate;
 - #50 has resolved its P1 correctness gate;
 - no identified P1 correctness release gate remains open;
-- the final portfolio audit has established readiness to proceed to
-  release-candidate validation;
-- `v1.0.0` has not yet been created and remains gated by successful completion
-  of that validation.
+- the final portfolio audit has been completed;
+- release-candidate validation completed successfully against maintained
+  `main` commit `4c036f5`;
+- release publication preparation is tracked through #62;
+- `v1.0.0` has not yet been created;
+- the exact final `main` state must still be validated after the release
+  preparation changes are integrated and before the tag is created.
 
 The first maintained portfolio release becomes eligible only after its
-documented readiness gates pass.
+documented readiness gates pass against the exact state selected for tagging.


### PR DESCRIPTION
## Summary

Prepares the maintained repository documentation for publication of the first
semantic-version release:

    v1.0.0

This work follows the completed portfolio modernization, final portfolio audit
and successful release-candidate validation.

Related issue:

#62

## Current validated state

The final portfolio audit was merged in PR #61.

The resulting maintained `main` state was release-candidate validated at:

    4c036f5209905819274b66741f7b12a67cd35c3e

Validation result:

    reference build:              PASS
    Clang compiler build:         PASS
    Doxygen generation:           PASS
    non-interactive regression:   32 / 32 PASS
    interactive signal tests:     11 / 11 PASS
    combined runtime regression:  43 / 43 PASS

No known P0 or P1 correctness finding from the completed quality audit remains
open.

## Changes

This PR reconciles maintained release-state documentation with the completed
release-candidate validation.

It updates:

- `README.md`
- `docs/development/evolution-roadmap.md`
- `docs/development/release-strategy.md`

The documentation now records that:

- the final portfolio audit is complete;
- release-candidate validation completed successfully;
- `v1.0.0` publication preparation is tracked through #62;
- the exact final `main` state must still be validated after this preparation
  is integrated;
- the annotated release tag must only be created after that final validation.

The maintained release sequence is now explicit:

    final portfolio audit
            |
            v
    release-candidate validation
            |
            v
    release-state documentation
            |
            v
    PR + CI integration
            |
            v
    exact-final-main validation
            |
            v
    annotated v1.0.0 tag
            |
            v
    matching GitHub Release

## Scope

This PR contains documentation-only release preparation.

It introduces no changes to:

- `src/`
- `include/`
- `libft/`
- `Makefile`
- `libft/Makefile`
- `Doxyfile`
- `.github/workflows/ci.yml`

The historical final audit record is intentionally unchanged.

The historical reference tag also remains unchanged:

    portfolio-baseline-2026-08

## Release relationship

This PR does not create `v1.0.0`.

After this PR is merged, the exact resulting `main` commit must be validated
again before the annotated tag and matching GitHub Release are created.

Refs #62