### PR TITLE
docs(release): finalize v1.0.0 publication state

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,11 +582,12 @@ baseline.
 The final portfolio audit and subsequent release-candidate validation have
 completed successfully.
 
-The first maintained `v1.0.0` release has not yet been published. Release
-preparation is tracked through
-[issue #62](https://github.com/LuisQAlmeida/42Minishell/issues/62), and the exact
-final `main` state must still be validated after those preparation changes are
-integrated and before the release tag is created.
+`v1.0.0` is defined as the first maintained semantic-version release.
+Its publication workflow is tracked through
+[issue #62](https://github.com/LuisQAlmeida/42Minishell/issues/62).
+
+The release workflow requires the exact final `main` state to pass validation
+immediately before the annotated tag and matching GitHub Release are created.
 
 The audit evidence and verdict are recorded in
 [`docs/development/final-portfolio-audit.md`](docs/development/final-portfolio-audit.md).

--- a/docs/development/evolution-roadmap.md
+++ b/docs/development/evolution-roadmap.md
@@ -469,9 +469,11 @@ resolved through #49 and #50.
 The final portfolio audit and subsequent release-candidate validation have
 completed successfully.
 
-The first maintained release is now in publication preparation under #62. The
-exact final `main` state must still be validated after release-state
-documentation is integrated and before the annotated `v1.0.0` tag is created.
+`v1.0.0` is defined as the first maintained semantic-version release, with
+publication tracked through #62.
+
+The release workflow requires validation of the exact final `main` state before
+the annotated tag and matching GitHub Release are created.
 
 This roadmap determines how future work is categorized and prioritized.
 

--- a/docs/development/release-strategy.md
+++ b/docs/development/release-strategy.md
@@ -514,22 +514,21 @@ This release strategy does not:
 
 ## Current Release State
 
-At the current maintained state:
+The maintained release state is defined by the following invariants:
 
-- `portfolio-baseline-2026-08` is the only existing tag;
-- it is an annotated historical tag;
-- no semantic-version maintained release exists;
-- `main` is the current maintained development baseline;
-- #49 has resolved its P1 correctness gate;
-- #50 has resolved its P1 correctness gate;
+- `portfolio-baseline-2026-08` remains the immutable annotated historical
+  reference;
+- `main` is the maintained integration branch;
+- #49 and #50 have resolved the identified P1 correctness gates;
 - no identified P1 correctness release gate remains open;
 - the final portfolio audit has been completed;
 - release-candidate validation completed successfully against maintained
   `main` commit `4c036f5`;
-- release publication preparation is tracked through #62;
-- `v1.0.0` has not yet been created;
-- the exact final `main` state must still be validated after the release
-  preparation changes are integrated and before the tag is created.
+- `v1.0.0` is defined as the first maintained semantic-version release;
+- publication of `v1.0.0` is tracked through #62;
+- the annotated release tag must point to the exact final `main` state validated
+  immediately before publication;
+- the matching GitHub Release must resolve to that same tag and source state.
 
-The first maintained portfolio release becomes eligible only after its
-documented readiness gates pass against the exact state selected for tagging.
+A maintained portfolio release is eligible only after its documented readiness
+gates pass against the exact state selected for tagging.


### PR DESCRIPTION
## Summary

Finalizes the maintained release-state documentation before publication of the
first semantic-version release:

    v1.0.0

This removes dynamic pre-publication wording that would become stale as soon as
the release is published and replaces it with durable release invariants.

Related issue:

#62

## Context

The repository-wide portfolio modernization is complete.

The final portfolio audit passed, release-candidate validation completed
successfully, and the subsequent release-preparation documentation was merged
through PR #63.

The current release workflow now requires one final integration step followed
by validation of the exact resulting `main` commit before tagging.

## Changes

This PR updates:

- `README.md`
- `docs/development/evolution-roadmap.md`
- `docs/development/release-strategy.md`

The documentation now describes stable release invariants rather than
time-sensitive pre-publication state.

In particular:

- `v1.0.0` is defined as the first maintained semantic-version release;
- publication is tracked through #62;
- the release tag must point to the exact final `main` state validated
  immediately before publication;
- the matching GitHub Release must resolve to that same tag and source state;
- the historical `portfolio-baseline-2026-08` reference remains immutable.

## Why this is needed

The previous wording correctly described the repository before publication but
would become stale immediately after `v1.0.0` was created.

This PR replaces statements such as:

    v1.0.0 has not yet been created
    the final main state must still be validated

with durable release-policy language that remains correct before and after
publication.

## Scope

Documentation only.

No changes are introduced to:

- `src/`
- `include/`
- `libft/`
- `Makefile`
- `libft/Makefile`
- `Doxyfile`
- `.github/workflows/ci.yml`

The historical final portfolio audit record is intentionally unchanged.

## Release sequence

After this PR is integrated:

    merge through PR + CI
            |
            v
    synchronize exact main
            |
            v
    final exact-main validation
            |
            v
    create annotated v1.0.0 tag
            |
            v
    push tag
            |
            v
    publish matching GitHub Release
            |
            v
    verify tag == release == validated commit
            |
            v
    close #62

This PR does not create the release.

Refs #62