### PR TITLE
docs: make Doxygen validation reproducible in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,3 +193,108 @@ jobs:
             printf '%s\n' "$libft_status"
             exit 1
           fi
+
+  documentation:
+    name: documentation
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Install documentation dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          sudo apt-get update
+          sudo apt-get install --yes doxygen
+
+      - name: Validate generated documentation
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          rm -rf build
+
+          doxygen Doxyfile
+
+          test -f build/doxygen/index.html
+
+          for symbol in \
+            t_toktype \
+            t_err \
+            t_token \
+            t_redir \
+            t_cmd \
+            t_shell \
+            ses_loop \
+            scn_line \
+            grm_pipeline \
+            exp_variables \
+            exe_pipeline \
+            blt_execute \
+            sta_env_set \
+            sig_set_interactive
+          do
+            if ! grep -RFl "$symbol" build/doxygen >/dev/null 2>&1; then
+              echo "Generated Minishell documentation is missing: $symbol"
+              exit 1
+            fi
+          done
+
+          for symbol in \
+            ft_printf \
+            ft_strlen \
+            ft_strdup \
+            ft_calloc
+          do
+            if ! grep -RFl "$symbol" build/doxygen >/dev/null 2>&1; then
+              echo "Generated Libft documentation is missing: $symbol"
+              exit 1
+            fi
+          done
+
+          rm -rf build
+
+          if [ -e build ]; then
+            echo "ERROR: generated documentation remains"
+            exit 1
+          fi
+
+      - name: Verify repository cleanliness
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          status_output="$(git status --porcelain --untracked-files=all)"
+
+          if [ -n "$status_output" ]; then
+            echo "ERROR: documentation validation modified the repository:"
+            printf '%s\n' "$status_output"
+            exit 1
+          fi
+
+          submodule_status="$(
+            git -C external/libft status --porcelain --untracked-files=all
+          )"
+
+          if [ -n "$submodule_status" ]; then
+            echo "ERROR: Libft submodule is not clean:"
+            printf '%s\n' "$submodule_status"
+            exit 1
+          fi
+
+          ignored_output="$(git clean -ndX)"
+
+          if [ -n "$ignored_output" ]; then
+            echo "ERROR: ignored generated files remain:"
+            printf '%s\n' "$ignored_output"
+            exit 1
+          fi
+
+          echo "PASS: repository and Libft submodule remain clean"

--- a/Doxyfile
+++ b/Doxyfile
@@ -4,7 +4,7 @@
 PROJECT_NAME           = "42 Minishell"
 PROJECT_BRIEF          = "Maintained API reference for the Minishell project"
 
-OUTPUT_DIRECTORY       = build/docs/doxygen
+OUTPUT_DIRECTORY       = build
 
 OPTIMIZE_OUTPUT_FOR_C  = YES
 TYPEDEF_HIDES_STRUCT   = YES
@@ -35,9 +35,10 @@ WARNINGS               = YES
 WARN_IF_UNDOCUMENTED   = YES
 WARN_IF_DOC_ERROR      = YES
 WARN_NO_PARAMDOC       = YES
-WARN_AS_ERROR          = NO
+WARN_AS_ERROR          = FAIL_ON_WARNINGS
 
 GENERATE_HTML          = YES
+HTML_OUTPUT            = doxygen
 GENERATE_LATEX         = NO
 
 GENERATE_TREEVIEW      = YES

--- a/README.md
+++ b/README.md
@@ -549,7 +549,27 @@ Historical-baseline and maintained-release policy is defined in
 
 A repository-controlled [`Doxyfile`](Doxyfile) generates a local HTML reference
 for the curated Minishell API and the public API exposed by the pinned Libft
-dependency. Generated output remains under `build/` and is not versioned.
+dependency.
+
+Generate the documentation directly from a clean repository state with:
+
+```sh
+doxygen Doxyfile
+```
+
+No output-directory preparation is required. Generated HTML is written to:
+
+```text
+build/doxygen/index.html
+```
+
+The generated `build/` tree remains ignored by Git and is not versioned.
+
+Doxygen warnings are treated as validation failures. A dedicated GitHub Actions
+documentation job generates the reference from a clean checkout, verifies
+representative Minishell and Libft API entities, removes generated output, and
+checks both the superproject and pinned Libft submodule for repository
+cleanliness.
 
 Hand-written architecture documentation remains authoritative for system-level
 design. Doxygen supplements it with data-model, interface, ownership and


### PR DESCRIPTION
## Summary

Makes the existing Minishell Doxygen documentation reproducible from a clean
checkout and validates it through a dedicated GitHub Actions job.

Closes #67.

## Existing documentation

The maintained repository already documents its curated public interface through:

```text
include/minishell.h
docs/development/api-documentation.md
```

The repository-controlled `Doxyfile` also includes the public header exposed by
the pinned Libft dependency:

```text
external/libft/libft/libft.h
```

The existing API documentation itself was confirmed to be warning-free and did
not require changes.

## Reproducible output

The previous configuration used:

```text
OUTPUT_DIRECTORY = build/docs/doxygen
```

which failed from a clean repository state when the intermediate parent
directories did not already exist.

The configuration now uses:

```text
OUTPUT_DIRECTORY = build
HTML_OUTPUT      = doxygen
```

so the complete documented workflow is simply:

```sh
doxygen Doxyfile
```

with generated HTML available at:

```text
build/doxygen/index.html
```

No manual directory preparation is required.

## Warning policy

Doxygen warnings are now validation failures:

```text
WARN_AS_ERROR = FAIL_ON_WARNINGS
```

Local validation with Doxygen 1.9.8 completed with:

```text
Doxygen status: 0
warning/error lines: 0
```

## Documentation CI

Adds a dedicated `documentation` job to the existing workflow.

The job:

1. checks out the repository recursively with submodules;
2. installs Doxygen;
3. removes previous generated output;
4. runs `doxygen Doxyfile`;
5. verifies `build/doxygen/index.html`;
6. verifies representative Minishell API entities;
7. verifies representative Libft API entities;
8. removes generated output;
9. verifies superproject cleanliness;
10. verifies Libft-submodule cleanliness;
11. verifies no ignored generated leftovers remain.

## Generated API validation

Representative Minishell entities verified locally:

```text
t_toktype
t_err
t_token
t_redir
t_cmd
t_shell
ses_loop
scn_line
grm_pipeline
exp_variables
exe_pipeline
blt_execute
sta_env_set
sig_set_interactive
```

Representative Libft entities verified:

```text
ft_printf
ft_strlen
ft_strdup
ft_calloc
```

Result:

```text
coverage status: 0
```

## Cleanup validation

After generation:

```text
build removed: PASS
Libft submodule clean: PASS
ignored leftovers: none
git diff --check: PASS
```

## Scope

Modified:

```text
.github/workflows/ci.yml
Doxyfile
README.md
```

Unchanged:

- `include/minishell.h`;
- production source;
- Makefile;
- tests;
- architecture documentation;
- project-management documentation;
- `.gitmodules`;
- Libft gitlink;
- runtime behaviour;
- existing function signatures;
- release tags.

## Dependency invariant

The pinned Libft revision remains:

```text
890089c0d12a29874e3a92facd92f9f455d1ff1c
```

Dependency migration is intentionally deferred to a separate compatibility
change.

## Release invariants

Published release:

```text
v1.0.0
d60e9118e1dc52a766369658e83c8767e00b960f
```

Historical baseline:

```text
portfolio-baseline-2026-08
7ba2005223e263964bf8ae3069da9ff54c2c2c2b
```

Both remain unchanged.

## Follow-up

README CI badge and central `42Portfolio` navigation will be standardized
separately.

The historical Libft pin will then be evaluated separately against maintained
`42Libft v1.0.0`, with the new documentation job acting as an additional
compatibility gate.