### PR TITLE
docs(readme): add portfolio navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # minishell
 
+[![CI](https://github.com/LuisQAlmeida/42Minishell/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/LuisQAlmeida/42Minishell/actions/workflows/ci.yml)
+
+> Part of my [42 Common Core portfolio](https://github.com/LuisQAlmeida/42Portfolio).
+
 > An interactive Unix shell written in C, exploring command processing,
 > process orchestration, pipelines, redirections, environment state and signals.
 


### PR DESCRIPTION
## Summary

Standardizes the maintained Minishell README header with the common portfolio
navigation used across the maintained 42 Common Core repositories.

Closes #69.

## Changes

Adds:

- the existing GitHub Actions CI status badge;
- a direct link to the central `42Portfolio` repository.

The README now begins with:

```markdown
# minishell

[![CI](https://github.com/LuisQAlmeida/42Minishell/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/LuisQAlmeida/42Minishell/actions/workflows/ci.yml)

> Part of my [42 Common Core portfolio](https://github.com/LuisQAlmeida/42Portfolio).
```

The existing project introduction remains unchanged.

## Scope

This pull request modifies only:

```text
README.md
```

It does not modify:

- production source;
- `include/minishell.h`;
- Makefile behaviour;
- tests;
- `.github/workflows/ci.yml`;
- `Doxyfile`;
- `.gitignore`;
- architecture documentation;
- project-management documentation;
- `.gitmodules`;
- the Libft gitlink;
- generated documentation;
- release tags.

## Validation

- `README.md` is the only changed file;
- the CI badge targets `.github/workflows/ci.yml`;
- the portfolio link targets `LuisQAlmeida/42Portfolio`;
- `git diff --check` passes;
- no source, build, test, CI, Doxygen, dependency or technical-documentation files changed.

## Dependency invariant

The pinned Libft revision remains:

```text
890089c0d12a29874e3a92facd92f9f455d1ff1c
```

Dependency migration is intentionally deferred to a separate compatibility
change.

## Release invariants

Published release:

```text
v1.0.0
d60e9118e1dc52a766369658e83c8767e00b960f
```

Historical baseline:

```text
portfolio-baseline-2026-08
7ba2005223e263964bf8ae3069da9ff54c2c2c2b
```

Both remain unchanged.

## Result

After this pull request, the maintained Minishell repository-presentation and
documentation consistency pass is complete:

- CI status badge;
- central portfolio navigation;
- no submission-specific 42 headers;
- maintained Doxygen API documentation;
- reproducible clean-tree Doxygen generation;
- warnings-as-errors;
- dedicated documentation CI;
- existing build and quality validation;
- immutable published release and historical baseline.

The historical Libft dependency alignment remains a separate follow-up.