### PR TITLE
chore(deps): align Libft with maintained v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,11 +338,12 @@ git submodule update --init --recursive
 Libft is maintained separately in `LuisQAlmeida/42Libft` and is consumed
 through the Git submodule at `external/libft`.
 
-The superproject Gitlink pins the dependency revision used by this maintained
-state. The initial externalized dependency revision is:
+The superproject Gitlink pins the exact dependency revision used by the
+maintained branch. It is currently aligned with the maintained `42Libft v1.0.0`
+release:
 
 ```text
-890089c0d12a29874e3a92facd92f9f455d1ff1c
+0227823923ca15b580a481c3fb929d7f1382f545
 ```
 
 The Makefile builds `external/libft/libft/libft.a` through Libft's own


### PR DESCRIPTION
## Summary

Aligns the maintained Minishell Libft dependency with the published
`42Libft v1.0.0` release.

Closes #71.

## Dependency update

The Git submodule at:

```text
external/libft
```

moves from the historical Libft portfolio baseline:

```text
890089c0d12a29874e3a92facd92f9f455d1ff1c
```

to the maintained `42Libft v1.0.0` release:

```text
0227823923ca15b580a481c3fb929d7f1382f545
```

The README now records that the maintained Minishell branch is aligned with
that exact maintained Libft release.

## Pre-migration compatibility audit

The Libft interface actually consumed by Minishell was identified from the
maintained source.

The following 16 Libft functions are consumed:

```text
ft_calloc
ft_isalnum
ft_isalpha
ft_isdigit
ft_itoa
ft_memcpy
ft_putchar_fd
ft_putendl_fd
ft_putstr_fd
ft_split
ft_strchr
ft_strdup
ft_strjoin
ft_strlen
ft_strncmp
ft_substr
```

All 16 remain declared by the `42Libft v1.0.0` public header:

```text
compatibility status: 0
```

## Libft source compatibility

Between the old pin and `42Libft v1.0.0`:

```text
PASS: no Libft implementation .c files changed
```

The relevant maintained Libft changes consist of repository documentation,
CI/Doxygen infrastructure, public-header documentation, and a Makefile
incremental-build fix.

The external build contract consumed by Minishell remains available:

```text
NAME = libft.a
all
clean
fclean
re
```

## Default compiler validation

A complete clean build against the new Libft pin succeeded:

```text
default build status: 0
PASS: ./minishell exists and is executable
PASS: external/libft/libft/libft.a exists
```

A repeated build also succeeded without rebuilding Libft:

```text
incremental status: 0
make[1]: Nothing to be done for 'all'.
```

## Clang validation

A complete clean Clang build against the new dependency succeeded:

```text
Clang build status: 0
PASS: Clang-built ./minishell exists
PASS: Clang-built Libft archive exists
```

A second Clang build did not relink Minishell:

```text
incremental status: 0
PASS: Clang second make did not relink
```

## Doxygen compatibility

The repository Doxygen configuration directly consumes:

```text
external/libft/libft/libft.h
```

Documentation generation against `42Libft v1.0.0` completed successfully:

```text
Doxygen status: 0
warning/error lines: 0
PASS: build/doxygen/index.html
coverage status: 0
```

Representative Minishell entities remained present:

```text
t_toktype
t_err
t_token
t_redir
t_cmd
t_shell
ses_loop
scn_line
grm_pipeline
exp_variables
exe_pipeline
blt_execute
sta_env_set
sig_set_interactive
```

Representative Libft entities remained present:

```text
ft_printf
ft_strlen
ft_strdup
ft_calloc
```

## Repository integrity

Only these paths are modified:

```text
README.md
external/libft
```

The following remain unchanged:

- production Minishell source;
- `include/minishell.h`;
- root Makefile;
- tests;
- `.github/workflows/ci.yml`;
- `Doxyfile`;
- `.gitignore`;
- architecture and project-management documentation;
- `.gitmodules`;
- runtime implementation;
- existing function signatures.

Additional checks:

```text
Libft submodule clean: PASS
build artefacts absent: PASS
generated build tree absent: PASS
ignored leftovers: none
out-of-scope diff: empty
git diff --check: PASS
```

## Dependency identity

The staged dependency state was verified explicitly:

```text
staged gitlink:
0227823923ca15b580a481c3fb929d7f1382f545

submodule HEAD:
0227823923ca15b580a481c3fb929d7f1382f545

Libft v1.0.0:
0227823923ca15b580a481c3fb929d7f1382f545
```

## Release invariants

Published Minishell release:

```text
v1.0.0
d60e9118e1dc52a766369658e83c8767e00b960f
```

Historical Minishell baseline:

```text
portfolio-baseline-2026-08
7ba2005223e263964bf8ae3069da9ff54c2c2c2b
```

Both remain unchanged.

The published Minishell `v1.0.0` remains an immutable snapshot of its original
validated dependency state. This Libft alignment applies only to the maintained
`main` line.